### PR TITLE
Feature/cleanup

### DIFF
--- a/ffrd-metadata-demo.ipynb
+++ b/ffrd-metadata-demo.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 363,
+   "execution_count": 93,
    "id": "00b5630e-846b-4168-a7b1-5df57ea8e6da",
    "metadata": {
     "tags": []
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 364,
+   "execution_count": 94,
    "id": "0f6177df-fd0b-4357-87c7-de525aabda38",
    "metadata": {
     "tags": []
@@ -31,10 +31,10 @@
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=Na4723759b2c3410db782ca32424c0f03 (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=N97477fc42eed43e19bac162cf91ff9c1 (<class 'rdflib.graph.Graph'>)>"
       ]
      },
-     "execution_count": 364,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 365,
+   "execution_count": 95,
    "id": "cd887a76-cf69-4df5-b12b-17403c87868c",
    "metadata": {
     "tags": []
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 366,
+   "execution_count": 96,
    "id": "ecfe6fbf-ea56-49d1-a4b8-75f36ca7069b",
    "metadata": {
     "tags": []
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 367,
+   "execution_count": 97,
    "id": "def1c3f3-7284-44df-94e0-da2080b1dd2f",
    "metadata": {
     "tags": []
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 368,
+   "execution_count": 98,
    "id": "e2572341-a3ae-43e3-9ff9-0c07030271a1",
    "metadata": {
     "tags": []
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 390,
+   "execution_count": 99,
    "id": "5d81f3ec-7377-4b9e-9be9-13aa641b2d99",
    "metadata": {
     "tags": []
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 391,
+   "execution_count": 100,
    "id": "2521f913-d77d-4203-808e-21bac4663575",
    "metadata": {
     "tags": []
@@ -204,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 371,
+   "execution_count": 101,
    "id": "9e4df143-41ab-46c8-b44d-a0a10e85a407",
    "metadata": {
     "tags": []
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 372,
+   "execution_count": 102,
    "id": "cf8198e5-93ef-42d3-901d-4823ad889f7f",
    "metadata": {
     "tags": []
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 373,
+   "execution_count": 103,
    "id": "e780dd70-ae7f-4eb1-bf1c-5ede15c4adb0",
    "metadata": {
     "tags": []
@@ -290,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 374,
+   "execution_count": 104,
    "id": "a79002e8-bb46-44a5-a152-33e1edba496c",
    "metadata": {
     "tags": []
@@ -302,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 375,
+   "execution_count": 105,
    "id": "ecce5fe9-8b9d-4e60-bbd6-158147cef6fe",
    "metadata": {
     "tags": []
@@ -327,7 +327,7 @@
     "    ?calib rascat:hydrographType ?hydroType .\n",
     "    ?gage dcterms:identifier ?gageID .\n",
     "    ?gage dcterms:title ?gageTitle .\n",
-    "    ?hydro rascat:nse ?nse .\n",
+    "    ?calib rascat:nse ?nse .\n",
     "    FILTER (?hydroType = \"Flow\")\n",
     "}}\n",
     "ORDER BY ASC(?nse)\n",
@@ -337,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 376,
+   "execution_count": 106,
    "id": "541aa967-fda1-4187-ba6e-507878bd10ed",
    "metadata": {
     "tags": []
@@ -347,16 +347,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CoalRiver -180.7 Nov2003 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p01 https://waterdata.usgs.gov/monitoring-location/03198350\n",
-      "CoalRiver -180.7 Nov2003 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p01 https://waterdata.usgs.gov/monitoring-location/03198500\n",
-      "CoalRiver -180.7 Nov2003 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p01 https://waterdata.usgs.gov/monitoring-location/03200500\n",
-      "CoalRiver -180.7 Jan1995 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p02 https://waterdata.usgs.gov/monitoring-location/03198500\n",
-      "CoalRiver -180.7 Jan1995 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p02 https://waterdata.usgs.gov/monitoring-location/03200500\n",
-      "CoalRiver -180.7 Jan1996 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p03 https://waterdata.usgs.gov/monitoring-location/03198500\n",
-      "CoalRiver -180.7 Jan1996 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p03 https://waterdata.usgs.gov/monitoring-location/03200500\n",
-      "CoalRiver -180.7 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03198350\n",
-      "CoalRiver -180.7 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03198500\n",
-      "CoalRiver -180.7 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03200500\n"
+      "UpperNew_Upper -7.27 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p04 https://waterdata.usgs.gov/monitoring-location/03164000\n",
+      "CoalRiver -1.97 Jan1996 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p03 https://waterdata.usgs.gov/monitoring-location/03198500\n",
+      "WatershedG9 -1.5141 Jan-1995 Calibration http://example.ffrd.fema.gov/kanawha/models/WatershedG9.p05 https://waterdata.usgs.gov/monitoring-location/03184000\n",
+      "UpperNew_Upper -1.22 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p04 https://waterdata.usgs.gov/monitoring-location/03161000\n",
+      "UpperNew_Lower -0.343 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Lower.p07 https://waterdata.usgs.gov/monitoring-location/03168000\n",
+      "UpperNew_Upper -0.34 Jan1996 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p03 https://waterdata.usgs.gov/monitoring-location/03164000\n",
+      "Kanawha_G1 -0.17704 Jan-1995 Calibration http://example.ffrd.fema.gov/kanawha/models/Kanawha_G1.p05 https://waterdata.usgs.gov/monitoring-location/03180500\n",
+      "WatershedG9 -0.058891 Jan-1996 Calibration http://example.ffrd.fema.gov/kanawha/models/WatershedG9.p06 https://waterdata.usgs.gov/monitoring-location/03184000\n",
+      "CoalRiver 0.04 Jan1995 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p02 https://waterdata.usgs.gov/monitoring-location/03198500\n",
+      "CoalRiver 0.07 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03200500\n"
      ]
     }
    ],
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 377,
+   "execution_count": 107,
    "id": "eaab81db-efcb-4419-955c-65dd12354a4e",
    "metadata": {
     "tags": []
@@ -414,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 378,
+   "execution_count": 108,
    "id": "1d289e20-ffc5-4d5a-8f26-8e49e9f604b8",
    "metadata": {
     "tags": []
@@ -448,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 379,
+   "execution_count": 109,
    "id": "b577b2ad-043e-4b5f-ab11-d25d654bf830",
    "metadata": {
     "tags": []
@@ -460,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 380,
+   "execution_count": 110,
    "id": "a84f2d50-4ad9-43cf-bb0a-332830274213",
    "metadata": {
     "tags": []
@@ -485,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 381,
+   "execution_count": 111,
    "id": "e8422663-b7f1-40f2-ab51-11c1eb8a80f1",
    "metadata": {
     "tags": []
@@ -517,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 382,
+   "execution_count": 112,
    "id": "cc4e5192-000e-4faa-819c-f523b2e95b7e",
    "metadata": {
     "tags": []
@@ -529,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 383,
+   "execution_count": 113,
    "id": "9b148d91-cae2-4706-85f0-ca76a7080332",
    "metadata": {
     "tags": []
@@ -541,10 +541,11 @@
     "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
     "PREFIX usgs_gages: <https://waterdata.usgs.gov/monitoring-location/>\n",
     "PREFIX kanawha_models: <http://example.ffrd.fema.gov/kanawha/models/>\n",
-    "SELECT DISTINCT ?model ?gage ?gageID\n",
+    "SELECT DISTINCT ?model ?gage ?gageID ?title\n",
     "WHERE {{\n",
     "    ?model a rascat:RasModel .\n",
     "    ?model rascat:hasPlan ?plan .\n",
+    "    ?model dcterms:title ?title .\n",
     "    ?plan rascat:hasCalibration ?calib .\n",
     "    ?calib rascat:fromStreamgage ?gage .\n",
     "    ?gage dcterms:identifier ?gageID .\n",
@@ -555,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 384,
+   "execution_count": 114,
    "id": "33055add-41d3-4ad4-8252-47af58d9b5bc",
    "metadata": {
     "tags": []
@@ -565,8 +566,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "http://example.ffrd.fema.gov/kanawha/models/New-LittleRiver.prj https://waterdata.usgs.gov/monitoring-location/03170000 03170000\n",
-      "http://example.ffrd.fema.gov/kanawha/models/New-LittleRiver.prj https://waterdata.usgs.gov/monitoring-location/03171000 03171000\n"
+      "New-Little River https://waterdata.usgs.gov/monitoring-location/03170000 03170000\n",
+      "New-Little River https://waterdata.usgs.gov/monitoring-location/03171000 03171000\n"
      ]
     }
    ],
@@ -578,12 +579,13 @@
     "    gage = row[1]\n",
     "    gage_urls.append(gage)\n",
     "    gageID = row[2]\n",
-    "    print(model, gage, gageID)"
+    "    title = row[3]\n",
+    "    print(title, gage, gageID)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 385,
+   "execution_count": 115,
    "id": "b748bbbf-63d7-4e2b-a29d-81199737e366",
    "metadata": {
     "tags": []
@@ -596,7 +598,7 @@
        " rdflib.term.URIRef('https://waterdata.usgs.gov/monitoring-location/03171000')]"
       ]
      },
-     "execution_count": 385,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -607,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 386,
+   "execution_count": 116,
    "id": "c7b8e149-4068-4e7e-a4ab-5b811dc41d33",
    "metadata": {
     "tags": []
@@ -628,7 +630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 387,
+   "execution_count": 117,
    "id": "0ca3d209-e87d-4b2f-abc8-7da8f7e5cf94",
    "metadata": {
     "tags": []
@@ -642,7 +644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 388,
+   "execution_count": 118,
    "id": "3f62eb2c-467c-4a93-bf1a-950421917ae5",
    "metadata": {
     "tags": []
@@ -662,7 +664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 389,
+   "execution_count": 119,
    "id": "b247f79a-b9b2-434e-8646-689a654e46fe",
    "metadata": {
     "tags": []
@@ -671,7 +673,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2a7d73c146074e75a90cd47ba996c8fd",
+       "model_id": "91790a6528004eb3bf599cec95a94134",
        "version_major": 2,
        "version_minor": 0
       },
@@ -679,7 +681,7 @@
        "Map(center=[37.089709445, -80.562974445], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_…"
       ]
      },
-     "execution_count": 389,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -702,7 +704,7 @@
     "    description = j['description']\n",
     "    gage_url = j['@id']\n",
     "    gage_popup = HTML()\n",
-    "    gage_popup.value = f\"<h3>{name}</h3><p>Used to calibrate <b>{model}</b></p><p>{description}</p><p><a target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\" href=\\\"{gage_url}\\\">{gage_url}</a></p>\"\n",
+    "    gage_popup.value = f\"<h3>{name}</h3><p>Used to calibrate model <b><a target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\" href=\\\"{model}\\\">{title}</a></b> (example link)</p><p>{description}</p><p><a target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\" href=\\\"{gage_url}\\\">{gage_url}</a></p>\"\n",
     "    marker = Marker(location=location, draggable=False, title=name)\n",
     "    marker.popup = gage_popup\n",
     "    m.add_layer(marker)\n",

--- a/ffrd-metadata-demo.ipynb
+++ b/ffrd-metadata-demo.ipynb
@@ -1,0 +1,651 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c1822c68-dd5d-47d1-9feb-5379dea14745",
+   "metadata": {},
+   "source": [
+    "# Kanawha / FFRD Metadata Demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
+   "id": "00b5630e-846b-4168-a7b1-5df57ea8e6da",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import rdflib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "id": "0f6177df-fd0b-4357-87c7-de525aabda38",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Graph identifier=N768e00367e6244a79fc5d467918b0b9e (<class 'rdflib.graph.Graph'>)>"
+      ]
+     },
+     "execution_count": 163,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g = rdflib.Graph()\n",
+    "g.parse(\"./kanawha.ttl\", format=\"turtle\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bcfb51a-b9fd-4b0c-9d45-f26244ca31bd",
+   "metadata": {},
+   "source": [
+    "## Query for models based a model creator name\n",
+    "Find models created by a particlar person."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "id": "cd887a76-cf69-4df5-b12b-17403c87868c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_creator = \"Mark McBroom\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 165,
+   "id": "ecfe6fbf-ea56-49d1-a4b8-75f36ca7069b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_creator = f\"\"\"\n",
+    "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
+    "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+    "SELECT DISTINCT ?title ?description ?model\n",
+    "WHERE {{\n",
+    "    ?model a rascat:RasModel .\n",
+    "    ?model dcterms:title ?title .\n",
+    "    ?model dcterms:description ?description .\n",
+    "    ?model dcterms:creator ?creators .\n",
+    "    ?model dcterms:creator [foaf:name \"{model_creator}\"] .\n",
+    "}}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "id": "def1c3f3-7284-44df-94e0-da2080b1dd2f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GauleySummersville_BLE_FEMA http://example.ffrd.fema.gov/kanawha/models/GSummersville_B.prj\n",
+      "GauleySummersville_BLE-C_FEMA http://example.ffrd.fema.gov/kanawha/models/GSummersville_C.prj\n",
+      "GauleyLower_BLE-C_FEMA http://example.ffrd.fema.gov/kanawha/models/GauleyLower_BLE_FEM.prj\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = g.query(query_creator)\n",
+    "for row in results:\n",
+    "    title = row[0]\n",
+    "    description = row[1]\n",
+    "    model = row[2]\n",
+    "    print(title, model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c4ca82e-6d14-42f7-9d59-1b3a4a5e0308",
+   "metadata": {},
+   "source": [
+    "## Query for models based on 2D mesh cell count\n",
+    "Find models with more than X cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "id": "9e4df143-41ab-46c8-b44d-a0a10e85a407",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cell_count = 400000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "id": "cf8198e5-93ef-42d3-901d-4823ad889f7f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_cell_count = f\"\"\"\n",
+    "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
+    "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+    "SELECT ?title ?description ?model ?geometry ?cellCount\n",
+    "WHERE {{\n",
+    "    ?model a rascat:RasModel .\n",
+    "    ?model dcterms:title ?title .\n",
+    "    ?model dcterms:description ?description .\n",
+    "    ?model rascat:hasGeometry ?geometry .\n",
+    "    ?geometry rascat:hasMesh2D ?mesh2D .\n",
+    "    ?mesh2D rascat:cellCount ?cellCount .\n",
+    "    FILTER (?cellCount > {cell_count})\n",
+    "}}\n",
+    "ORDER BY DESC(?cellCount)    \n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "id": "e780dd70-ae7f-4eb1-bf1c-5ede15c4adb0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GauleyLower_BLE-C_FEMA 1088388 http://example.ffrd.fema.gov/kanawha/models/GauleyLower_BLE_FEM.g01\n",
+      "UpperNew_Upper 1064723 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.g01\n",
+      "GauleySummersville_BLE-C_FEMA 954995 http://example.ffrd.fema.gov/kanawha/models/GSummersville_C.g01\n",
+      "UpperNew_Lower 800701 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Lower.g03\n",
+      "ElkMiddle 761035 http://example.ffrd.fema.gov/kanawha/models/ElkMiddle.g01\n",
+      "ElkMiddle 761035 http://example.ffrd.fema.gov/kanawha/models/ElkMiddle.g02\n",
+      "GauleySummersville_BLE_FEMA 587360 http://example.ffrd.fema.gov/kanawha/models/GSummersville_B.g01\n",
+      "Upper Kanawha 537254 http://example.ffrd.fema.gov/kanawha/models/UpperKanawha.g01\n",
+      "New-Little River 517580 http://example.ffrd.fema.gov/kanawha/models/New-LittleRiver.g01\n",
+      "Bluestone Local - Compass 2D BLE 417852 http://example.ffrd.fema.gov/kanawha/models/BluestoneLocal.g01\n",
+      "Watershed G3 411065 http://example.ffrd.fema.gov/kanawha/models/WatershedG3.g01\n",
+      "Watershed G3 411065 http://example.ffrd.fema.gov/kanawha/models/WatershedG3.g02\n",
+      "Watershed G3 411065 http://example.ffrd.fema.gov/kanawha/models/WatershedG3.g03\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = g.query(query_cell_count)\n",
+    "for row in results:\n",
+    "    title = row[0]\n",
+    "    description = row[1]\n",
+    "    model = row[2]\n",
+    "    geometry = row[3]\n",
+    "    cell_count = row[4]\n",
+    "    print(title, cell_count, geometry)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1348d5fc-7643-449e-975d-69183bbd8d47",
+   "metadata": {},
+   "source": [
+    "## Query based on calibration metrics\n",
+    "Identify the top 10 Plan calibration hydrographs by according to the Nash-Sutcliffe Efficiency metric."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 170,
+   "id": "a79002e8-bb46-44a5-a152-33e1edba496c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "limit = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "id": "ecce5fe9-8b9d-4e60-bbd6-158147cef6fe",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_calibration = f\"\"\"\n",
+    "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
+    "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+    "PREFIX usgs_gages: <https://waterdata.usgs.gov/monitoring-location/>\n",
+    "SELECT ?title ?description ?model ?flow ?gage ?nse ?flowTitle ?gageTitle ?hydroType ?plan ?planTitle\n",
+    "WHERE {{\n",
+    "    ?model a rascat:RasModel .\n",
+    "    ?model dcterms:title ?title .\n",
+    "    ?model dcterms:description ?description .\n",
+    "    ?model rascat:hasPlan ?plan .\n",
+    "    ?plan rascat:hasUnsteadyFlow ?flow .\n",
+    "    ?plan rascat:hasCalibrationHydrograph ?hydro .\n",
+    "    ?plan dcterms:title ?planTitle .\n",
+    "    ?flow dcterms:title ?flowTitle .\n",
+    "    ?hydro rascat:fromStreamgage ?gage .\n",
+    "    ?hydro rascat:hydrographType ?hydroType .\n",
+    "    ?gage dcterms:identifier ?gageID .\n",
+    "    ?gage dcterms:title ?gageTitle .\n",
+    "    ?hydro rascat:nse ?nse .\n",
+    "    FILTER (?hydroType = \"Flow\")\n",
+    "}}\n",
+    "ORDER BY ASC(?nse)\n",
+    "LIMIT {limit}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "id": "541aa967-fda1-4187-ba6e-507878bd10ed",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "UpperNew_Upper -7.27 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p04 https://waterdata.usgs.gov/monitoring-location/03164000\n",
+      "CoalRiver -1.97 Jan1996 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p03 https://waterdata.usgs.gov/monitoring-location/03198500\n",
+      "WatershedG9 -1.5141 Jan-1995 Calibration http://example.ffrd.fema.gov/kanawha/models/WatershedG9.p05 https://waterdata.usgs.gov/monitoring-location/03184000\n",
+      "UpperNew_Upper -1.22 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p04 https://waterdata.usgs.gov/monitoring-location/03161000\n",
+      "UpperNew_Lower -0.343 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Lower.p07 https://waterdata.usgs.gov/monitoring-location/03168000\n",
+      "UpperNew_Upper -0.34 Jan1996 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p03 https://waterdata.usgs.gov/monitoring-location/03164000\n",
+      "Kanawha_G1 -0.17704 Jan-1995 Calibration http://example.ffrd.fema.gov/kanawha/models/Kanawha_G1.p05 https://waterdata.usgs.gov/monitoring-location/03180500\n",
+      "WatershedG9 -0.058891 Jan-1996 Calibration http://example.ffrd.fema.gov/kanawha/models/WatershedG9.p06 https://waterdata.usgs.gov/monitoring-location/03184000\n",
+      "CoalRiver 0.04 Jan1995 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p02 https://waterdata.usgs.gov/monitoring-location/03198500\n",
+      "CoalRiver 0.07 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03200500\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = g.query(query_calibration)\n",
+    "for row in results:\n",
+    "    title = row[0]\n",
+    "    description = row[1]\n",
+    "    model = row[2]\n",
+    "    flow = row[3]\n",
+    "    gage = row[4]\n",
+    "    nse = row[5]\n",
+    "    flow_title = row[6]\n",
+    "    gage_title = row[7]\n",
+    "    hydro_type = row[8]\n",
+    "    plan = row[9]\n",
+    "    plan_title = row[10]\n",
+    "    print(title, nse, plan_title, plan, gage)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ae9851b-d7a8-4400-a70e-f61b449a6854",
+   "metadata": {},
+   "source": [
+    "## List all surface roughness landuse/landcover sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 188,
+   "id": "eaab81db-efcb-4419-955c-65dd12354a4e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_lulc = \"\"\"\n",
+    "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
+    "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+    "PREFIX usgs_gages: <https://waterdata.usgs.gov/monitoring-location/>\n",
+    "SELECT ?landuseDesc (GROUP_CONCAT(DISTINCT ?title; separator=\", \") as ?titles)\n",
+    "WHERE {\n",
+    "    ?model a rascat:RasModel .\n",
+    "    ?model dcterms:title ?title .\n",
+    "    ?model dcterms:description ?description .\n",
+    "    ?model rascat:hasGeometry ?geom .\n",
+    "    ?geom rascat:hasRoughness ?rough .\n",
+    "    ?rough rascat:hasLanduseLandcover ?landuse .\n",
+    "    ?landuse dcterms:description ?landuseDesc .\n",
+    "}\n",
+    "GROUP BY ?landuseDesc\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 190,
+   "id": "1d289e20-ffc5-4d5a-8f26-8e49e9f604b8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Custom land cover analysis of NAIP 2022 imagery BasinG6, G5, Greenbrier_G7, Greenbrier_G8, Kanawha_G1, Kanawha_G2, Watershed G3, Watershed G4, WatershedG9\n",
+      "National Land Cover Database 2019 (CONUS) Bluestone Local - Compass 2D BLE, Bluestone_Upper, CoalRiver, GauleySummersville_BLE_FEMA, New-Little River, Upper Kanawha, UpperNew_Lower, UpperNew_Upper\n",
+      "Remote Sensing Data processed by WSP ElkMiddle\n",
+      "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022 GauleySummersville_BLE-C_FEMA, GauleyLower_BLE-C_FEMA\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = g.query(query_lulc)\n",
+    "for row in results:\n",
+    "    lulc_desc = row[0]\n",
+    "    titles = row[1]\n",
+    "    print(lulc_desc, titles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0cf6802-1bdc-4ae6-a117-b70c70d3874b",
+   "metadata": {},
+   "source": [
+    "## Identify any models that used a certain USGS gage for calibration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 175,
+   "id": "b577b2ad-043e-4b5f-ab11-d25d654bf830",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gage = \"03187500\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "id": "a84f2d50-4ad9-43cf-bb0a-332830274213",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_gage = f\"\"\"\n",
+    "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
+    "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+    "PREFIX usgs_gages: <https://waterdata.usgs.gov/monitoring-location/>\n",
+    "SELECT DISTINCT ?model ?gage ?gageID\n",
+    "WHERE {{\n",
+    "    ?model a rascat:RasModel .\n",
+    "    ?model rascat:hasPlan ?plan .\n",
+    "    ?plan rascat:hasCalibrationHydrograph ?hydro .\n",
+    "    ?hydro rascat:fromStreamgage ?gage .\n",
+    "    ?gage dcterms:identifier ?gageID .\n",
+    "    FILTER (?gageID = \"{gage}\")\n",
+    "}}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "id": "e8422663-b7f1-40f2-ab51-11c1eb8a80f1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "http://example.ffrd.fema.gov/kanawha/models/GSummersville_B.prj\n",
+      "http://example.ffrd.fema.gov/kanawha/models/GSummersville_C.prj\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = g.query(query_gage)\n",
+    "for row in results:\n",
+    "    model = row[0]\n",
+    "    print(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de9c9092-21c3-45d0-86b9-bbb9fbbdb9c6",
+   "metadata": {},
+   "source": [
+    "## Map USGS gages associated with a model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "id": "cc4e5192-000e-4faa-819c-f523b2e95b7e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model = \"New-LittleRiver.prj\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "id": "9b148d91-cae2-4706-85f0-ca76a7080332",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_gages = f\"\"\"\n",
+    "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
+    "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+    "PREFIX usgs_gages: <https://waterdata.usgs.gov/monitoring-location/>\n",
+    "PREFIX kanawha: <http://ffrd.fema.gov/models/kanawha/>\n",
+    "SELECT DISTINCT ?model ?gage ?gageID\n",
+    "WHERE {{\n",
+    "    ?model a rascat:RasModel .\n",
+    "    ?model rascat:hasPlan ?plan .\n",
+    "    ?plan rascat:hasCalibrationHydrograph ?hydro .\n",
+    "    ?hydro rascat:fromStreamgage ?gage .\n",
+    "    ?gage dcterms:identifier ?gageID .\n",
+    "    FILTER (?model = kanawha:{model})\n",
+    "}}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "id": "33055add-41d3-4ad4-8252-47af58d9b5bc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "results = g.query(query_gages)\n",
+    "gage_urls = []\n",
+    "for row in results:\n",
+    "    gage = row[1]\n",
+    "    gage_urls.append(gage)\n",
+    "    gageID = row[2]\n",
+    "    print(gage, gageID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "id": "b748bbbf-63d7-4e2b-a29d-81199737e366",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 181,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gage_urls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 182,
+   "id": "c7b8e149-4068-4e7e-a4ab-5b811dc41d33",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import requests\n",
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "def get_ld_json(url: str) -> dict:\n",
+    "    parser = \"html.parser\"\n",
+    "    req = requests.get(url)\n",
+    "    soup = BeautifulSoup(req.text, parser)\n",
+    "    return json.loads(\"\".join(soup.find(\"script\", {\"type\":\"application/ld+json\"}).contents))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 183,
+   "id": "0ca3d209-e87d-4b2f-abc8-7da8f7e5cf94",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gage_ld_jsons = []\n",
+    "for gage_url in gage_urls:\n",
+    "    gage_ld_jsons.append(get_ld_json(gage_url))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "id": "3f62eb2c-467c-4a93-bf1a-950421917ae5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(gage_ld_jsons)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
+   "id": "b247f79a-b9b2-434e-8646-689a654e46fe",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "StatisticsError",
+     "evalue": "mean requires at least one data point",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mStatisticsError\u001b[0m                           Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[185], line 5\u001b[0m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mipywidgets\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m HTML\n\u001b[0;32m      3\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mstatistics\u001b[39;00m\n\u001b[1;32m----> 5\u001b[0m center_lat \u001b[38;5;241m=\u001b[39m \u001b[43mstatistics\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmean\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;28;43mfloat\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mi\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mgeo\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mlatitude\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mi\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mgage_ld_jsons\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m      6\u001b[0m center_lng \u001b[38;5;241m=\u001b[39m statistics\u001b[38;5;241m.\u001b[39mmean([\u001b[38;5;28mfloat\u001b[39m(i[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mgeo\u001b[39m\u001b[38;5;124m'\u001b[39m][\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mlongitude\u001b[39m\u001b[38;5;124m'\u001b[39m]) \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m gage_ld_jsons])\n\u001b[0;32m      8\u001b[0m center \u001b[38;5;241m=\u001b[39m (center_lat, center_lng)\n",
+      "File \u001b[1;32m~\\.pyenv\\pyenv-win\\versions\\3.10.10\\lib\\statistics.py:328\u001b[0m, in \u001b[0;36mmean\u001b[1;34m(data)\u001b[0m\n\u001b[0;32m    326\u001b[0m n \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlen\u001b[39m(data)\n\u001b[0;32m    327\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m n \u001b[38;5;241m<\u001b[39m \u001b[38;5;241m1\u001b[39m:\n\u001b[1;32m--> 328\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m StatisticsError(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mmean requires at least one data point\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m    329\u001b[0m T, total, count \u001b[38;5;241m=\u001b[39m _sum(data)\n\u001b[0;32m    330\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m count \u001b[38;5;241m==\u001b[39m n\n",
+      "\u001b[1;31mStatisticsError\u001b[0m: mean requires at least one data point"
+     ]
+    }
+   ],
+   "source": [
+    "from ipyleaflet import Map, Marker\n",
+    "from ipywidgets import HTML\n",
+    "import statistics\n",
+    "\n",
+    "center_lat = statistics.mean([float(i['geo']['latitude']) for i in gage_ld_jsons])\n",
+    "center_lng = statistics.mean([float(i['geo']['longitude']) for i in gage_ld_jsons])\n",
+    "\n",
+    "center = (center_lat, center_lng)\n",
+    "\n",
+    "m = Map(center=center, zoom=9)\n",
+    "\n",
+    "for j in gage_ld_jsons:\n",
+    "    location = (float(j['geo']['latitude']), float(j['geo']['longitude']))\n",
+    "    name = j['name']\n",
+    "    description = j['description']\n",
+    "    gage_url = j['@id']\n",
+    "    gage_popup = HTML()\n",
+    "    gage_popup.value = f\"<h3>{name}</h3><p>Used to calibrate <b>{model}</b></p><p>{description}</p><p><a target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\" href=\\\"{gage_url}\\\">{gage_url}</a></p>\"\n",
+    "    marker = Marker(location=location, draggable=False, title=name)\n",
+    "    marker.popup = gage_popup\n",
+    "    m.add_layer(marker)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bbaa593-4a8b-422e-bc85-22bc5022ae4c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ffrd-metadata-demo.ipynb
+++ b/ffrd-metadata-demo.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": 363,
    "id": "00b5630e-846b-4168-a7b1-5df57ea8e6da",
    "metadata": {
     "tags": []
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": 364,
    "id": "0f6177df-fd0b-4357-87c7-de525aabda38",
    "metadata": {
     "tags": []
@@ -31,10 +31,10 @@
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=N768e00367e6244a79fc5d467918b0b9e (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=Na4723759b2c3410db782ca32424c0f03 (<class 'rdflib.graph.Graph'>)>"
       ]
      },
-     "execution_count": 163,
+     "execution_count": 364,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": 365,
    "id": "cd887a76-cf69-4df5-b12b-17403c87868c",
    "metadata": {
     "tags": []
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
+   "execution_count": 366,
    "id": "ecfe6fbf-ea56-49d1-a4b8-75f36ca7069b",
    "metadata": {
     "tags": []
@@ -77,6 +77,7 @@
     "query_creator = f\"\"\"\n",
     "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
     "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+    "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
     "SELECT DISTINCT ?title ?description ?model\n",
     "WHERE {{\n",
     "    ?model a rascat:RasModel .\n",
@@ -90,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": 367,
    "id": "def1c3f3-7284-44df-94e0-da2080b1dd2f",
    "metadata": {
     "tags": []
@@ -117,6 +118,83 @@
   },
   {
    "cell_type": "markdown",
+   "id": "87344750-1462-4c10-b213-23a3eb777340",
+   "metadata": {},
+   "source": [
+    "## Query for models based on the creator organization\n",
+    "\n",
+    "Find models created by people who belong to a certain organization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 368,
+   "id": "e2572341-a3ae-43e3-9ff9-0c07030271a1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "org_name = \"Freese and Nichols\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 390,
+   "id": "5d81f3ec-7377-4b9e-9be9-13aa641b2d99",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_org = f\"\"\"\n",
+    "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
+    "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+    "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "SELECT DISTINCT ?title ?description ?model ?orgName ?jvName\n",
+    "WHERE {{\n",
+    "    ?model a rascat:RasModel .\n",
+    "    ?model dcterms:title ?title .\n",
+    "    ?model dcterms:description ?description .\n",
+    "    ?model dcterms:creator ?creator .\n",
+    "    ?creator foaf:member ?org .\n",
+    "    ?org foaf:name ?orgName .\n",
+    "    ?org foaf:member ?jv .\n",
+    "    ?jv foaf:name ?jvName .\n",
+    "    FILTER (?orgName = \"{org_name}\")\n",
+    "}}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 391,
+   "id": "2521f913-d77d-4203-808e-21bac4663575",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Upper Kanawha http://example.ffrd.fema.gov/kanawha/models/UpperKanawha.prj Freese and Nichols ARC JV\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = g.query(query_org)\n",
+    "for row in results:\n",
+    "    title = row[0]\n",
+    "    description = row[1]\n",
+    "    model = row[2]\n",
+    "    org_name = row[3]\n",
+    "    jv_name = row[4]\n",
+    "    print(title, model, org_name, jv_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7c4ca82e-6d14-42f7-9d59-1b3a4a5e0308",
    "metadata": {},
    "source": [
@@ -126,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": 371,
    "id": "9e4df143-41ab-46c8-b44d-a0a10e85a407",
    "metadata": {
     "tags": []
@@ -138,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": 372,
    "id": "cf8198e5-93ef-42d3-901d-4823ad889f7f",
    "metadata": {
     "tags": []
@@ -164,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 373,
    "id": "e780dd70-ae7f-4eb1-bf1c-5ede15c4adb0",
    "metadata": {
     "tags": []
@@ -212,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 374,
    "id": "a79002e8-bb46-44a5-a152-33e1edba496c",
    "metadata": {
     "tags": []
@@ -224,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 375,
    "id": "ecce5fe9-8b9d-4e60-bbd6-158147cef6fe",
    "metadata": {
     "tags": []
@@ -242,11 +320,11 @@
     "    ?model dcterms:description ?description .\n",
     "    ?model rascat:hasPlan ?plan .\n",
     "    ?plan rascat:hasUnsteadyFlow ?flow .\n",
-    "    ?plan rascat:hasCalibrationHydrograph ?hydro .\n",
+    "    ?plan rascat:hasCalibration ?calib .\n",
     "    ?plan dcterms:title ?planTitle .\n",
     "    ?flow dcterms:title ?flowTitle .\n",
-    "    ?hydro rascat:fromStreamgage ?gage .\n",
-    "    ?hydro rascat:hydrographType ?hydroType .\n",
+    "    ?calib rascat:fromStreamgage ?gage .\n",
+    "    ?calib rascat:hydrographType ?hydroType .\n",
     "    ?gage dcterms:identifier ?gageID .\n",
     "    ?gage dcterms:title ?gageTitle .\n",
     "    ?hydro rascat:nse ?nse .\n",
@@ -259,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 376,
    "id": "541aa967-fda1-4187-ba6e-507878bd10ed",
    "metadata": {
     "tags": []
@@ -269,16 +347,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "UpperNew_Upper -7.27 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p04 https://waterdata.usgs.gov/monitoring-location/03164000\n",
-      "CoalRiver -1.97 Jan1996 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p03 https://waterdata.usgs.gov/monitoring-location/03198500\n",
-      "WatershedG9 -1.5141 Jan-1995 Calibration http://example.ffrd.fema.gov/kanawha/models/WatershedG9.p05 https://waterdata.usgs.gov/monitoring-location/03184000\n",
-      "UpperNew_Upper -1.22 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p04 https://waterdata.usgs.gov/monitoring-location/03161000\n",
-      "UpperNew_Lower -0.343 Jun2016 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Lower.p07 https://waterdata.usgs.gov/monitoring-location/03168000\n",
-      "UpperNew_Upper -0.34 Jan1996 http://example.ffrd.fema.gov/kanawha/models/UpperNew_Upper.p03 https://waterdata.usgs.gov/monitoring-location/03164000\n",
-      "Kanawha_G1 -0.17704 Jan-1995 Calibration http://example.ffrd.fema.gov/kanawha/models/Kanawha_G1.p05 https://waterdata.usgs.gov/monitoring-location/03180500\n",
-      "WatershedG9 -0.058891 Jan-1996 Calibration http://example.ffrd.fema.gov/kanawha/models/WatershedG9.p06 https://waterdata.usgs.gov/monitoring-location/03184000\n",
-      "CoalRiver 0.04 Jan1995 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p02 https://waterdata.usgs.gov/monitoring-location/03198500\n",
-      "CoalRiver 0.07 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03200500\n"
+      "CoalRiver -180.7 Nov2003 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p01 https://waterdata.usgs.gov/monitoring-location/03198350\n",
+      "CoalRiver -180.7 Nov2003 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p01 https://waterdata.usgs.gov/monitoring-location/03198500\n",
+      "CoalRiver -180.7 Nov2003 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p01 https://waterdata.usgs.gov/monitoring-location/03200500\n",
+      "CoalRiver -180.7 Jan1995 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p02 https://waterdata.usgs.gov/monitoring-location/03198500\n",
+      "CoalRiver -180.7 Jan1995 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p02 https://waterdata.usgs.gov/monitoring-location/03200500\n",
+      "CoalRiver -180.7 Jan1996 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p03 https://waterdata.usgs.gov/monitoring-location/03198500\n",
+      "CoalRiver -180.7 Jan1996 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p03 https://waterdata.usgs.gov/monitoring-location/03200500\n",
+      "CoalRiver -180.7 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03198350\n",
+      "CoalRiver -180.7 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03198500\n",
+      "CoalRiver -180.7 Jun2016 http://example.ffrd.fema.gov/kanawha/models/CoalRiver.p04 https://waterdata.usgs.gov/monitoring-location/03200500\n"
      ]
     }
    ],
@@ -309,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 377,
    "id": "eaab81db-efcb-4419-955c-65dd12354a4e",
    "metadata": {
     "tags": []
@@ -336,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": 378,
    "id": "1d289e20-ffc5-4d5a-8f26-8e49e9f604b8",
    "metadata": {
     "tags": []
@@ -346,10 +424,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Custom land cover analysis of NAIP 2022 imagery BasinG6, G5, Greenbrier_G7, Greenbrier_G8, Kanawha_G1, Kanawha_G2, Watershed G3, Watershed G4, WatershedG9\n",
-      "National Land Cover Database 2019 (CONUS) Bluestone Local - Compass 2D BLE, Bluestone_Upper, CoalRiver, GauleySummersville_BLE_FEMA, New-Little River, Upper Kanawha, UpperNew_Lower, UpperNew_Upper\n",
-      "Remote Sensing Data processed by WSP ElkMiddle\n",
-      "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022 GauleySummersville_BLE-C_FEMA, GauleyLower_BLE-C_FEMA\n"
+      "Custom machine learning land cover analysis of NAIP 2022 imagery\n",
+      "National Land Cover Database 2019 (CONUS)\n",
+      "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022\n"
      ]
     }
    ],
@@ -358,7 +435,7 @@
     "for row in results:\n",
     "    lulc_desc = row[0]\n",
     "    titles = row[1]\n",
-    "    print(lulc_desc, titles)"
+    "    print(lulc_desc)"
    ]
   },
   {
@@ -371,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 379,
    "id": "b577b2ad-043e-4b5f-ab11-d25d654bf830",
    "metadata": {
     "tags": []
@@ -383,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 380,
    "id": "a84f2d50-4ad9-43cf-bb0a-332830274213",
    "metadata": {
     "tags": []
@@ -398,8 +475,8 @@
     "WHERE {{\n",
     "    ?model a rascat:RasModel .\n",
     "    ?model rascat:hasPlan ?plan .\n",
-    "    ?plan rascat:hasCalibrationHydrograph ?hydro .\n",
-    "    ?hydro rascat:fromStreamgage ?gage .\n",
+    "    ?plan rascat:hasCalibration ?calib .\n",
+    "    ?calib rascat:fromStreamgage ?gage .\n",
     "    ?gage dcterms:identifier ?gageID .\n",
     "    FILTER (?gageID = \"{gage}\")\n",
     "}}\n",
@@ -408,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 381,
    "id": "e8422663-b7f1-40f2-ab51-11c1eb8a80f1",
    "metadata": {
     "tags": []
@@ -440,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 382,
    "id": "cc4e5192-000e-4faa-819c-f523b2e95b7e",
    "metadata": {
     "tags": []
@@ -452,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 383,
    "id": "9b148d91-cae2-4706-85f0-ca76a7080332",
    "metadata": {
     "tags": []
@@ -463,40 +540,50 @@
     "PREFIX rascat: <http://www.example.org/rascat/0.1#>\n",
     "PREFIX dcterms: <http://purl.org/dc/terms/>\n",
     "PREFIX usgs_gages: <https://waterdata.usgs.gov/monitoring-location/>\n",
-    "PREFIX kanawha: <http://ffrd.fema.gov/models/kanawha/>\n",
+    "PREFIX kanawha_models: <http://example.ffrd.fema.gov/kanawha/models/>\n",
     "SELECT DISTINCT ?model ?gage ?gageID\n",
     "WHERE {{\n",
     "    ?model a rascat:RasModel .\n",
     "    ?model rascat:hasPlan ?plan .\n",
-    "    ?plan rascat:hasCalibrationHydrograph ?hydro .\n",
-    "    ?hydro rascat:fromStreamgage ?gage .\n",
+    "    ?plan rascat:hasCalibration ?calib .\n",
+    "    ?calib rascat:fromStreamgage ?gage .\n",
     "    ?gage dcterms:identifier ?gageID .\n",
-    "    FILTER (?model = kanawha:{model})\n",
+    "    FILTER (?model = kanawha_models:{model})\n",
     "}}\n",
     "\"\"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 384,
    "id": "33055add-41d3-4ad4-8252-47af58d9b5bc",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "http://example.ffrd.fema.gov/kanawha/models/New-LittleRiver.prj https://waterdata.usgs.gov/monitoring-location/03170000 03170000\n",
+      "http://example.ffrd.fema.gov/kanawha/models/New-LittleRiver.prj https://waterdata.usgs.gov/monitoring-location/03171000 03171000\n"
+     ]
+    }
+   ],
    "source": [
     "results = g.query(query_gages)\n",
     "gage_urls = []\n",
     "for row in results:\n",
+    "    model = row[0]\n",
     "    gage = row[1]\n",
     "    gage_urls.append(gage)\n",
     "    gageID = row[2]\n",
-    "    print(gage, gageID)"
+    "    print(model, gage, gageID)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 385,
    "id": "b748bbbf-63d7-4e2b-a29d-81199737e366",
    "metadata": {
     "tags": []
@@ -505,10 +592,11 @@
     {
      "data": {
       "text/plain": [
-       "[]"
+       "[rdflib.term.URIRef('https://waterdata.usgs.gov/monitoring-location/03170000'),\n",
+       " rdflib.term.URIRef('https://waterdata.usgs.gov/monitoring-location/03171000')]"
       ]
      },
-     "execution_count": 181,
+     "execution_count": 385,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -519,7 +607,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 386,
    "id": "c7b8e149-4068-4e7e-a4ab-5b811dc41d33",
    "metadata": {
     "tags": []
@@ -540,7 +628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 387,
    "id": "0ca3d209-e87d-4b2f-abc8-7da8f7e5cf94",
    "metadata": {
     "tags": []
@@ -554,7 +642,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 388,
    "id": "3f62eb2c-467c-4a93-bf1a-950421917ae5",
    "metadata": {
     "tags": []
@@ -564,7 +652,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[]\n"
+      "[{'@context': ['https://opengeospatial.github.io/ELFIE/json-ld/hyf.jsonld'], '@id': 'https://waterdata.usgs.gov/monitoring-location/03170000/', '@type': 'http://www.opengeospatial.org/standards/waterml2/hy_features/HY_HydroLocation', 'name': 'LITTLE RIVER AT GRAYSONTOWN, VA', 'description': 'Monitoring location 03170000 is associated with a Stream in Pulaski County, Virginia. Current conditions of Discharge, Gage height, and Precipitation are available. Water data back to 1928 are available online.', 'sameAs': 'https://waterdata.usgs.gov/nwis/inventory/?site_no=03170000', 'HY_HydroLocationType': 'hydrometricStation', 'geo': {'@type': 'schema:GeoCoordinates', 'latitude': '37.03762635', 'longitude': '-80.5567239'}, 'image': 'https://labs.waterdata.usgs.gov/api/graph-images/monitoring-location/03170000/?parameterCode=00065'}, {'@context': ['https://opengeospatial.github.io/ELFIE/json-ld/hyf.jsonld'], '@id': 'https://waterdata.usgs.gov/monitoring-location/03171000/', '@type': 'http://www.opengeospatial.org/standards/waterml2/hy_features/HY_HydroLocation', 'name': 'NEW RIVER AT RADFORD, VA', 'description': 'Monitoring location 03171000 is associated with a Stream in Pulaski County, Virginia. Current conditions of Discharge and Gage height are available. Water data back to 1878 are available online.', 'sameAs': 'https://waterdata.usgs.gov/nwis/inventory/?site_no=03171000', 'HY_HydroLocationType': 'hydrometricStation', 'geo': {'@type': 'schema:GeoCoordinates', 'latitude': '37.14179254', 'longitude': '-80.56922499'}, 'image': 'https://labs.waterdata.usgs.gov/api/graph-images/monitoring-location/03171000/?parameterCode=00065'}]\n"
      ]
     }
    ],
@@ -574,23 +662,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 389,
    "id": "b247f79a-b9b2-434e-8646-689a654e46fe",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "ename": "StatisticsError",
-     "evalue": "mean requires at least one data point",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mStatisticsError\u001b[0m                           Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[185], line 5\u001b[0m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mipywidgets\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m HTML\n\u001b[0;32m      3\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mstatistics\u001b[39;00m\n\u001b[1;32m----> 5\u001b[0m center_lat \u001b[38;5;241m=\u001b[39m \u001b[43mstatistics\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmean\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;28;43mfloat\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mi\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mgeo\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mlatitude\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mi\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mgage_ld_jsons\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m      6\u001b[0m center_lng \u001b[38;5;241m=\u001b[39m statistics\u001b[38;5;241m.\u001b[39mmean([\u001b[38;5;28mfloat\u001b[39m(i[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mgeo\u001b[39m\u001b[38;5;124m'\u001b[39m][\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mlongitude\u001b[39m\u001b[38;5;124m'\u001b[39m]) \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m gage_ld_jsons])\n\u001b[0;32m      8\u001b[0m center \u001b[38;5;241m=\u001b[39m (center_lat, center_lng)\n",
-      "File \u001b[1;32m~\\.pyenv\\pyenv-win\\versions\\3.10.10\\lib\\statistics.py:328\u001b[0m, in \u001b[0;36mmean\u001b[1;34m(data)\u001b[0m\n\u001b[0;32m    326\u001b[0m n \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlen\u001b[39m(data)\n\u001b[0;32m    327\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m n \u001b[38;5;241m<\u001b[39m \u001b[38;5;241m1\u001b[39m:\n\u001b[1;32m--> 328\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m StatisticsError(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mmean requires at least one data point\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m    329\u001b[0m T, total, count \u001b[38;5;241m=\u001b[39m _sum(data)\n\u001b[0;32m    330\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m count \u001b[38;5;241m==\u001b[39m n\n",
-      "\u001b[1;31mStatisticsError\u001b[0m: mean requires at least one data point"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a7d73c146074e75a90cd47ba996c8fd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[37.089709445, -80.562974445], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_…"
+      ]
+     },
+     "execution_count": 389,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [

--- a/kanawha-yaml/BasinG6.yml
+++ b/kanawha-yaml/BasinG6.yml
@@ -2,10 +2,13 @@ description: '2D rain-on-mesh BLE model of the 6th of nine Greenbrier River basi
 creators:
   - name: Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name: Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name: Dami George
     email: dami.george@wsp.com
+    org: wsp
 connected_models:
   - model: G5.prj
     direction: upstream
@@ -19,6 +22,7 @@ flows:
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
       spatially_varied: true
+      event: jan_1995
   BasinG6.u02:
     title: Jan-1995 Inital Conditions
     hyetograph: 
@@ -26,6 +30,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
   BasinG6.u03:
     title: Jan-1995 Calibration
     hyetograph:
@@ -33,6 +38,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
   BasinG6.u04:
     title: Nov-2003 Initial Conditions
     hyetograph:
@@ -40,6 +46,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
   BasinG6.u05:
     title: Nov-2003 Calibration
     hyetograph:
@@ -47,6 +54,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
   BasinG6.u06:
     title: Jun-2016 Calibration
     hyetograph:
@@ -54,6 +62,7 @@ flows:
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
       spatially_varied: true
+      event: jun_2016
   BasinG6.u07:
     title: Jan-1996 Calibration
     hyetograph:
@@ -61,6 +70,7 @@ flows:
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
       spatially_varied: true
+      event: jan_1996
 geometries:
   BasinG6.g01:
     title: GreenbrierBasinG6_LiDAR
@@ -176,4 +186,5 @@ plans:
         rsr: 0.59411
         pbias: -0.11989
         r2: 0.90879
+        event: jun_2016
 title: BasinG6

--- a/kanawha-yaml/BasinG6.yml
+++ b/kanawha-yaml/BasinG6.yml
@@ -81,8 +81,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -101,8 +100,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -119,8 +117,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/BasinG6.yml
+++ b/kanawha-yaml/BasinG6.yml
@@ -75,12 +75,10 @@ geometries:
   BasinG6.g01:
     title: GreenbrierBasinG6_LiDAR
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -97,12 +95,10 @@ geometries:
   BasinG6.g02:
     title: LiDAR_G6_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -119,8 +115,7 @@ geometries:
   BasinG6.g03:
     title: LiDAR_G6_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/BluestoneLocal.yml
+++ b/kanawha-yaml/BluestoneLocal.yml
@@ -2,6 +2,7 @@ description: ''
 creators:
   - name: Pete Williams
     email: pete.williams@aecom.com
+    org: AECOM
 ras_version: 6.3.0
 modified: 10/25/2022 23:59
 flows:
@@ -12,6 +13,7 @@ flows:
       description: January 1995 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 1/12/1995 00:00
       end_datetime:   1/24/1995 00:00
+      event: jan_1995
   BluestoneLocal.u02:
     title: JAN1996
     hyetograph:
@@ -19,6 +21,7 @@ flows:
       description: January 1996 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 1/15/1996 00:00
       end_datetime:   1/30/1996 00:00
+      event: jan_1996
   BluestoneLocal.u03:
     title: NOV2003
     hyetograph:
@@ -26,6 +29,7 @@ flows:
       description: November 2003 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 11/7/2003 00:00
       end_datetime:   11/27/2003 00:00
+      event: nov_2003
   BluestoneLocal.u04:
     title: JUN2016
     hyetograph:
@@ -33,6 +37,7 @@ flows:
       description: June 2016 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 6/20/2016 12:00
       end_datetime:   7/3/2016 00:00
+      event: jun_2016
 geometries:
   BluestoneLocal.g01:
     title: BL-1
@@ -67,6 +72,7 @@ plans:
         rsr:   0.253
         pbias: 0.253
         r2:    0.946
+        event: jan_1995
   BluestoneLocal.p02:
     description: null
     flow: u02
@@ -81,6 +87,7 @@ plans:
         rsr:   0.36
         pbias: -1.896
         r2:    0.88
+        event: jan_1996
   BluestoneLocal.p03:
     description: null
     flow: u03
@@ -95,6 +102,7 @@ plans:
         rsr:   0.23
         pbias: 6.839
         r2:    0.95
+        event: nov_2003
   BluestoneLocal.p04:
     description: null
     flow: u04
@@ -109,6 +117,7 @@ plans:
         rsr:   1.14
         pbias: 20.672
         r2:    0.29
+        event: jun_2016
 
       - from_streamgage: 03179800
         hydrograph_type: Stage
@@ -118,4 +127,5 @@ plans:
         rsr:   1.11
         pbias: 35.55
         r2:    0.01
+        event: jun_2016
 title: Bluestone Local - Compass 2D BLE

--- a/kanawha-yaml/Bluestone_Upper.yml
+++ b/kanawha-yaml/Bluestone_Upper.yml
@@ -5,8 +5,10 @@ ras_version: 6.3.1
 creators:
   - name: KC Robinson
     email: kc.robinson@aecom.com
+    org: AECOM
   - name: Ryan Phol
     email: ryan.pohl@aecom.com
+    org: AECOM
 modified: 10/18/2022 18:25
 flows:
   Bluestone_Upper.u06:
@@ -16,6 +18,7 @@ flows:
       spatially_varied: true
       start_datetime: 11/6/2003 13:00
       end_datetime:   11/24/2003 0:00
+      event: nov_2003
   Bluestone_Upper.u07:
     title: Jan1995_ExcessPrecip_Baseflow
     hyetograph:
@@ -23,6 +26,7 @@ flows:
       spatially_varied: true
       start_datetime: 1/5/1995 14:00
       end_datetime:   1/29/1995 12:00
+      event: jan_1995
   Bluestone_Upper.u08:
     title: Jan1996_ExcessPrecip_Baseflow
     hyetograph:
@@ -30,6 +34,7 @@ flows:
       description: January to February 1996 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 1/14/1996 13:00
       end_datetime:   2/6/1996 0:00
+      event: jan_1996
   Bluestone_Upper.u09:
     title: Jun2016_ExcessPrecip_Baseflow
     hyetograph:
@@ -37,6 +42,7 @@ flows:
       start_datetime: 6/20/2016 13:00
       end_datetime:   7/3/2016 0:00
       spatially_varied: true
+      event: jun_2016
 geometries:
   Bluestone_Upper.g07:
     title: 400ft_Refined_100ft_NoSCS
@@ -78,6 +84,7 @@ plans:
         rsr:   0.39
         pibas: 18.06
         r2:    0.88
+        event: jan_1995
 
       - from_streamgage: "03177710"
         hydrograph_type: Stage
@@ -87,6 +94,7 @@ plans:
         rsr:   0.66
         pibas: 12.81
         r2:    0.62
+        event: jan_1995
 
   Bluestone_Upper.p16:
     description: '14 Jan - 6 Feb 1996 (UTC) excess precip from HMS plus baseflow
@@ -108,6 +116,7 @@ plans:
         rsr:   0.42
         pbias: 13.83
         r2:    0.88
+        event: jan_1996
 
       - from_streamgage: "03177710"
         hydrograph_type: Stage
@@ -117,6 +126,7 @@ plans:
         rsr:   0.33
         pbias: 13.16
         r2:    0.91
+        event: jan_1996
 
   Bluestone_Upper.p17:
     description: 'Jun 20 - Jul 3, 2016 (UTC) using Excess Precipitation from Corps
@@ -139,6 +149,7 @@ plans:
         rsr:   0.99
         pbias: 34.29
         r2:    0.28
+        event: jun_2016
 
       - from_streamgage: "03177710"
         hydrograph_type: Stage
@@ -148,6 +159,7 @@ plans:
         rsr:   1.09
         pbias: 14.84
         r2:    0.01
+        event: jun_2016
 
   Bluestone_Upper.p18:
     description: 'Nov 6-24, 2003 (UTC) using Excess Precip from calibrated HEC-HMS
@@ -170,5 +182,6 @@ plans:
         rsr:   0.27
         pibas: 13.5
         r2:    0.94
+        event: nov_2003
 
 title: Bluestone_Upper

--- a/kanawha-yaml/CoalRiver.yml
+++ b/kanawha-yaml/CoalRiver.yml
@@ -4,8 +4,10 @@ Technical Advisement to FY21 IRWA with USACE'
 creators:
   - name: Yacoub Raheem
     email: yacoub.raheem@aecom.com
+    org: AECOM
   - name: Courtney Fournier
     email: courtney.fournier@aecom.com
+    org: AECOM
 ras_version: "6.3.1"
 modified: 10/13/2022 15:11
 flows:
@@ -15,24 +17,28 @@ flows:
       description: November 2003 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 11/6/2003 13:00
       end_datetime:   11/24/2003 00:00
+      event: nov_2003
   CoalRiver.u02:
-    title: Jan1995a
+    title: Jan1995
     hyetograph:
       description: January 1995 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 1/6/1995 0:00
       end_datetime:   1/25/1995 00:00
+      event: jan_1995
   CoalRiver.u03:
     title: Jan1996
     hyetograph:
       description: January 1996 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 1/15/1996 0:00
       end_datetime:   2/1/1996 00:00
+      event: jan_1996
   CoalRiver.u04:
     title: Jun2016
     hyetograph:
       description: June 2016 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 6/20/2016 12:00
       end_datetime:   7/1/2016 00:00
+      event: jun_2016
 geometries:
   CoalRiver.g01:
     title: CoalRiver
@@ -64,6 +70,7 @@ plans:
         rsr:   0.36
         pbias: 14.17
         r2:    0.89
+        event: nov_2003
 
       - from_streamgage: 03198500
         start_datetime:  1/6/2003 13:00
@@ -72,6 +79,7 @@ plans:
         rsr:   0.39
         pbias: 12.06
         r2:    0.86
+        event: nov_2003
 
       - from_streamgage: 03198350
         start_datetime:  1/6/2003 13:00
@@ -80,6 +88,7 @@ plans:
         rsr:   0.32
         pbias: 4.51
         r2:    0.90
+        event: nov_2003
 
   CoalRiver.p02:
     description: null
@@ -94,6 +103,7 @@ plans:
         rsr:   0.84
         pbias: 20.36
         r2:    0.32
+        event: jan_1995
 
       - from_streamgage: 03198500
         start_datetime: 1/6/1995 0:00
@@ -102,6 +112,7 @@ plans:
         rsr:   0.95
         pbias: 35.98
         r2:    0.23
+        event: jan_1995
 
   CoalRiver.p03:
     description: null
@@ -116,6 +127,7 @@ plans:
         rsr:   0.51
         pbias: 8.02
         r2:    0.73
+        event: jan_1996
 
       - from_streamgage: 03198500
         start_datetime: 1/15/1996 0:00
@@ -124,6 +136,7 @@ plans:
         rsr:   1.67
         pbias: -32.24
         r2:    0.08
+        event: jan_1996
 
   CoalRiver.p04:
     description: null
@@ -138,6 +151,7 @@ plans:
         rsr:   0.96
         pbias: 38.21
         r2:    0.27
+        event: jun_2016
 
       - from_streamgage: 03198500
         start_datetime: 6/20/2016 12:00
@@ -146,6 +160,7 @@ plans:
         rsr:   0.80
         pbias: 31.69
         r2:    0.50
+        event: jun_2016
 
       - from_streamgage: 03198350
         start_datetime: 6/20/2016 12:00
@@ -154,5 +169,6 @@ plans:
         rsr:   0.65
         pbias: 25.13
         r2:    0.73
+        event: jun_2016
 
 title: CoalRiver

--- a/kanawha-yaml/ElkMiddle.yml
+++ b/kanawha-yaml/ElkMiddle.yml
@@ -55,11 +55,9 @@ geometries:
   ElkMiddle.g01:
     title: ElkMiddle
     roughness:
-      landuse:
-        description: Remote Sensing Data processed by WSP
+      landuse: wsp_landuse
     precip_losses:
-      landuse:
-        description: Remote Sensing Data processed by WSP
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -76,11 +74,9 @@ geometries:
   ElkMiddle.g02:
     title: ElkMiddle_1996
     roughness:
-      landuse:
-        description: Remote Sensing Data processed by WSP
+      landuse: wsp_landuse
     precip_losses:
-      landuse:
-        description: Remote Sensing Data processed by WSP
+      landuse: wsp_landuse
       soils:
         uri: https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo
     mesh2d:

--- a/kanawha-yaml/ElkMiddle.yml
+++ b/kanawha-yaml/ElkMiddle.yml
@@ -7,13 +7,13 @@ modified: 10/19/2022 19:55
 creators:
   - name: "Kevan Lee Lum"
     email: "kevan.leelum@wsp.com"
-    organization: "ARC"
+    org: WSP
   - name: "Britton Wells"
     email: "britton.wells@wsp.com"
-    organization: "ARC"
+    org: WSP
   - name: "Masoud Meshkat"
     email: "masoud.meshkat@wsp.com"
-    organization: "ARC"
+    org: WSP
 flows:
   ElkMiddle.u02:
     title: ElkMiddle_Nov2003
@@ -22,6 +22,7 @@ flows:
       start_datetime: 2003-11-06 12:00:00
       end_datetime: 2003-11-28 12:00:00
       spatially_varied: true
+      event: nov_2003
 
   ElkMiddle.u04:
     title: ElkMiddle_Jan1995
@@ -30,6 +31,7 @@ flows:
       start_datetime: 1995-01-05 12:00:00
       end_datetime:   1995-01-29 12:00:00
       spatially_varied: true
+      event: jan_1995
 
   ElkMiddle.u05:
     title: ElkMiddle_Jan1996
@@ -38,6 +40,7 @@ flows:
       start_datetime: 1996-01-14 12:00:00
       end_datetime:   1996-02-07 11:00:00
       spatially_varied: true
+      event: jan_1996
 
   ElkMiddle.u06:
     title: ElkMiddle_Jun2016
@@ -46,6 +49,7 @@ flows:
       start_datetime: 2016-06-20 12:00:00
       end_datetime:   2016-07-04 12:00:00
       spatially_varied: true
+      event: jun_2016
 
 geometries:
   ElkMiddle.g01:
@@ -102,6 +106,7 @@ plans:
         rsr:    0.82996
         pbias:  -0.16572
         r2:     0.7701
+        event: nov_2003
 
       - start_datetime: 2003-11-11
         end_datetime: 2003-11-21
@@ -111,6 +116,7 @@ plans:
         rsr:    0.36328
         pbias:  -0.13772
         r2:     0.93277
+        event: nov_2003
 
       - start_datetime: 2003-11-11
         end_datetime: 2003-11-21
@@ -120,6 +126,7 @@ plans:
         rsr:    0.30843
         pbias:  13.164
         r2:     0.92731
+        event: nov_2003
 
       - start_datetime: 2003-11-11
         end_datetime: 2003-11-21
@@ -129,6 +136,7 @@ plans:
         rsr:    0.51156
         pbias:  0.24529
         r2:     0.90156
+        event: nov_2003
   ElkMiddle.p03:
     description: null
     flow: u05
@@ -143,6 +151,7 @@ plans:
         rsr:    0.78902
         pbias:  0.1821
         r2:     0.65615
+        event: jan_1996
 
       - start_datetime: 1996-01-15
         end_datetime:   1996-01-22
@@ -152,6 +161,7 @@ plans:
         rsr:    0.84782
         pbias:  0.35148
         r2:     0.61136
+        event: jan_1996
 
       - start_datetime: 1996-01-15
         end_datetime:   1996-01-22
@@ -161,6 +171,7 @@ plans:
         rsr:    1.4724
         pbias:  0.78082
         r2:     0.61415
+        event: jan_1996
   ElkMiddle.p04:
     description: null
     flow: u06
@@ -175,6 +186,7 @@ plans:
         rsr:    0.83896
         pbias:  -0.068283
         r2:     0.56463
+        event: jun_2016
 
       - start_datetime: 2016-06-20
         end_datetime:   2016-06-30
@@ -184,6 +196,7 @@ plans:
         rsr:    1.0997
         pbias:  -0.28261
         r2:     0.74283
+        event: jun_2016
 
 
       - start_datetime: 2016-06-20
@@ -194,6 +207,7 @@ plans:
         rsr:    0.62162
         pbias:  -28.881
         r2:     0.91515
+        event: jun_2016
 
       - start_datetime: 2016-06-20
         end_datetime:   2016-06-30
@@ -203,6 +217,7 @@ plans:
         rsr:    0.62702
         pbias:  -0.39992
         r2:     0.85544
+        event: jun_2016
 
       - start_datetime: 2016-06-20
         end_datetime:   2016-06-30
@@ -212,6 +227,7 @@ plans:
         rsr:    0.25266
         pbias:  -1.8492
         r2:     0.93743
+        event: jun_2016
 
       - start_datetime: 2016-06-20
         end_datetime:   2016-06-30
@@ -221,6 +237,7 @@ plans:
         rsr:    0.47899
         pbias:  0.12879
         r2:     0.81636
+        event: jun_2016
   ElkMiddle.p06:
     description: null
     flow: u04
@@ -235,6 +252,7 @@ plans:
         rsr:    1.3554
         pbias:  -0.11895
         r2:     0.6511
+        event: jan_1995
 
 
       - start_datetime: 1995-01-05
@@ -245,6 +263,7 @@ plans:
         rsr:    1.0726
         pbias:  -0.22115
         r2:     0.6714
+        event: jan_1995
 
 
       - start_datetime: 1995-01-05
@@ -255,6 +274,7 @@ plans:
         rsr:    0.75204
         pbias:  7.7577
         r2:     0.62639
+        event: jan_1995
 
 
       - start_datetime: 1995-01-05
@@ -265,4 +285,5 @@ plans:
         rsr:    1.5419
         pbias:  0.21848
         r2:     0.65966
+        event: jan_1995
 title: ElkMiddle

--- a/kanawha-yaml/G5.yml
+++ b/kanawha-yaml/G5.yml
@@ -71,12 +71,10 @@ geometries:
   G5.g01:
     title: GreenbrierBasinG5_LiDAR
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -93,12 +91,10 @@ geometries:
   G5.g02:
     title: LiDAR_G5_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -115,8 +111,7 @@ geometries:
   G5.g03:
     title: LiDAR_G5_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/G5.yml
+++ b/kanawha-yaml/G5.yml
@@ -2,10 +2,13 @@ description: '2D rain-on-mesh BLE model of the 5th of nine Greenbrier River basi
 creators:
   - name: Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name: Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name: Dami George
     email: dami.george@wsp.com
+    org: wsp
 connected_models:
   - model: WatershedG4.prj
     direction: upstream
@@ -19,6 +22,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
   G5.u05:
     title: Jan-1996 Initial Conditions
   G5.u06:
@@ -27,36 +31,42 @@ flows:
       description: Gridded precipitation data from the January 1995 event
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
+      event: jan_1995
   G5.u07:
     title: Nov-2003 Initial Conditions
     hyetograph:
       description: Gridded precipitation data from the November 2003 event
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
+      event: nov_2003
   G5.u08:
     title: Nov-2003 Calibration
     hyetograph:
       description: Gridded precipitation data from the November 2003 event
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
+      event: nov_2003
   G5.u09:
     title: Jun-2016 Initial Conditions
     hyetograph:
       description: Gridded precipitation data from the June 2016 event
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
+      event: jun_2016
   G5.u10:
     title: Jun-2016 Calibration
     hyetograph:
       description: Gridded precipitation data from the June 2016 event
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
+      event: jun_2016
   G5.u11:
     title: Jan-1996 Calibration
     hyetograph:
       description: Gridded precipitation data from the January 1996 event
       start_datetime: 1/5/1996 12:00
       end_datetime: 1/29/1996 12:00
+      event: jan_1996
 geometries:
   G5.g01:
     title: GreenbrierBasinG5_LiDAR

--- a/kanawha-yaml/G5.yml
+++ b/kanawha-yaml/G5.yml
@@ -77,8 +77,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -97,8 +96,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -115,8 +113,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/GSummersville_B.yml
+++ b/kanawha-yaml/GSummersville_B.yml
@@ -54,7 +54,7 @@ geometries:
     precip_losses:
       landuse: nlcd
       soils: ssurgo
-    structures: wv_clearinghouse
+    structures: wv_clearinghouse_structures
     terrain:
       bathymetry:
         description: Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE.

--- a/kanawha-yaml/GSummersville_B.yml
+++ b/kanawha-yaml/GSummersville_B.yml
@@ -5,8 +5,10 @@ modified: 10/20/2022 21:43
 creators:
   - name:  Daniyal Siddiqui 
     email: daniyal.siddiqui@mbakerintl.com
+    org: baker
   - name:  Mark McBroom
     email: mmcbroom@mbakerintl.com
+    org: baker
 flows:
   GSummersville_B.u01:
     title: GauleeSummersville_FloodPlain_Nov2003
@@ -15,6 +17,7 @@ flows:
       start_datetime: 11/6/2003 13:00
       end_datetime:   11/28/2003 12:00
       spatially_varied: true
+      event: nov_2003
 
   GSummersville_B.u03:
     title: GauleeSummersville_FloodPlain_Jan1995
@@ -23,6 +26,7 @@ flows:
       start_datetime:  1/5/1995 12:00
       end_datetime:    1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
 
   GSummersville_B.u05:
     title: GauleeSummersville_FloodPlain_Jan1996
@@ -31,6 +35,7 @@ flows:
       start_datetime: 1/14/1996 13:00
       end_datetime:   2/7/1996 10:00
       spatially_varied: true
+      event: jan_1996
 
   GSummersville_B.u07:
     title: GauleeSummersville_FloodPlain_Jun2016
@@ -39,6 +44,7 @@ flows:
       start_datetime: 6/20/2016 13:00
       end_datetime:   7/4/2016 12:00
       spatially_varied: true
+      event: jun_2016
 
 geometries:
   GSummersville_B.g01:
@@ -78,6 +84,7 @@ plans:
         rsr:   1.02
         pbias: 1.29
         r2:    0.66
+        event: jan_1996
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Stage
@@ -87,6 +94,7 @@ plans:
         rsr:   0.64
         pbias: -0.20
         r2:    0.74
+        event: jan_1996
 
       - from_streamgage: 03187000 # Gauley River at Camden ON Gauley, WV
         hydrograph_type: Stage
@@ -96,6 +104,7 @@ plans:
         rsr:   1.33
         pbias: -0.17
         r2:    0.60
+        event:  jan_1996
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Stage
@@ -105,6 +114,7 @@ plans:
         rsr:   2.22
         pbias: -0.12
         r2:    0.70
+        event: jan_1996
   GSummersville_B.p02:
     description: null
     flow: u01
@@ -119,6 +129,7 @@ plans:
         rsr:    0.653
         pbias:  1.181
         r2:     0.607
+        event: nov_2003
 
       - from_streamgage: 01389100 # Gauley River Near Craigsville, WV
         hydrograph_type: "Stage"
@@ -128,6 +139,7 @@ plans:
         rsr:    0.48
         pbias:  0.05
         r2:     0.87
+        event: nov_2003
 
       - from_streamgage: 03187000 # Gauley River at Camden ON Gauley, WV
         hydrograph_type: Stage
@@ -137,6 +149,7 @@ plans:
         rsr:    0.75
         pbias:  -0.13
         r2:     0.91
+        event: nov_2003
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Stage
@@ -146,6 +159,7 @@ plans:
         rsr:    1.19
         pbias:  -0.07
         r2:     0.91
+        event: nov_2003
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Flow
@@ -155,6 +169,7 @@ plans:
         rsr:    0.35
         pbias:  22.28
         r2:     0.90
+        event: nov_2003
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Flow
@@ -164,6 +179,7 @@ plans:
         rsr:    0.22
         pbias:  31.76
         r2:     0.98
+        event: nov_2003
 
       - from_streamgage: 03186500 # Williams River at Dyer, WV
         hydrograph_type: Flow
@@ -173,6 +189,8 @@ plans:
         rsr:    0.37
         pbias:  26.08
         r2:     0.96
+        event: nov_2003
+
   GSummersville_B.p11:
     description: null
     flow: u07
@@ -187,6 +205,7 @@ plans:
         rsr:   0.34
         pbias: -0.11
         r2:    0.93
+        event: jun_2016
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Stage
@@ -196,6 +215,7 @@ plans:
         rsr:   0.31
         pbias: -0.01
         r2:    0.91
+        event: jun_2016
 
       - from_streamgage: 03187000 # Gauley River at Camden ON Gauley, WV
         hydrograph_type: Stage
@@ -205,6 +225,7 @@ plans:
         rsr:   0.50
         pbias: -0.08
         r2:    0.83
+        event: jun_2016
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Stage
@@ -214,6 +235,7 @@ plans:
         rsr:   1.53
         pbias: -0.10
         r2:    0.84
+        event: jun_2016
 
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
@@ -224,6 +246,7 @@ plans:
         rsr:   0.2
         pbias: -5.06
         r2:    0.96
+        event: jun_2016
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Flow
@@ -233,6 +256,7 @@ plans:
         rsr:   0.53
         pbias: 1.20
         r2:    0.87
+        event: jun_2016
 
       - from_streamgage: 03186500 # Williams River at Dyer, WV
         hydrograph_type: Flow
@@ -242,6 +266,7 @@ plans:
         rsr:   0.19
         pbias: -4.63
         r2:    0.96
+        event: jun_2016
 
       - from_streamgage: 03188900 # Laurel Creek Near Fenwick, WV
         hydrograph_type: Flow
@@ -251,6 +276,7 @@ plans:
         rsr:   0.3
         pbias: 16.09
         r2:    0.92
+        event: jun_2016
   GSummersville_B.p12:
     description: null
     flow: u03
@@ -265,6 +291,7 @@ plans:
         rsr:   1.05
         pbias: -0.27
         r2:    0.98
+        event: jan_1995
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Stage
@@ -274,6 +301,7 @@ plans:
         rsr:   0.34
         pbias: 0.03
         r2:    0.98
+        event: jan_1995
 
       - from_streamgage: 03187000 # Gauley River at Camden ON Gauley, WV
         hydrograph_type: Stage
@@ -283,6 +311,7 @@ plans:
         rsr:   1.18
         pbias: -0.08
         r2:    0.76
+        event: jan_1995
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Stage
@@ -292,4 +321,5 @@ plans:
         rsr:   2.03
         pbias: -0.07
         r2:    0.89
+        event: jan_1995
 title: GauleySummersville_BLE_FEMA

--- a/kanawha-yaml/GSummersville_B.yml
+++ b/kanawha-yaml/GSummersville_B.yml
@@ -76,7 +76,7 @@ plans:
     geom: g01
     title: Unsteady_MultiHazard_Jan1996
     hydrographs:
-      - from_streamgage: "?USACE" # Summersville Lake / USACE
+      - from_streamgage: "USACE_Summersville_Lake" # Summersville Lake / USACE
         hydrograph_type: Stage
         start_datetime: 1/1/1985 11:00
         end_datetime:   12/31/2021 11:00
@@ -123,7 +123,7 @@ plans:
     hydrographs:
       - start_datetime: 1/1/1985 11:00
         end_datetime:   12/31/2021 11:00
-        from_streamgage: "?USACE" # Summersville Lake / USACE
+        from_streamgage: "USACE_Summersville_Lake" # Summersville Lake / USACE
         hydrograph_type: "Stage"
         nse:    0.574
         rsr:    0.653
@@ -131,7 +131,7 @@ plans:
         r2:     0.607
         event: nov_2003
 
-      - from_streamgage: 01389100 # Gauley River Near Craigsville, WV
+      - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: "Stage"
         start_datetime: 12/1/1994 00:30
         end_datetime:   7/31/2016 22:30
@@ -197,7 +197,7 @@ plans:
     geom: g01
     title: Unsteady_MultiHazard_Jun2016
     hydrographs:
-      - from_streamgage: "?USACE" # Summersville Lake / USACE
+      - from_streamgage: "USACE_Summersville_Lake" # Summersville Lake / USACE
         hydrograph_type: Stage
         start_datetime: 1/1/1985 11:00
         end_datetime:   12/31/2021 11:00
@@ -283,7 +283,7 @@ plans:
     geom: g01
     title: Unsteady_MultiHazard_Jan1995
     hydrographs:
-      - from_streamgage: "?USACE" # Summersville Lake / USACE
+      - from_streamgage: "USACE_Summersville_Lake" # Summersville Lake / USACE
         hydrograph_type: Stage
         start_datetime: 1/1/1985 11:00
         end_datetime:   12/31/2021 11:00

--- a/kanawha-yaml/GSummersville_C.yml
+++ b/kanawha-yaml/GSummersville_C.yml
@@ -54,7 +54,7 @@ geometries:
     precip_losses:
       landuse: baker_landuse
       soils: ssurgo
-    structures: wv_clearinghouse
+    structures: wv_clearinghouse_structures
     mesh2d:
       nominal_cell_size: 200
       breaklines_min_cell_size: 50

--- a/kanawha-yaml/GSummersville_C.yml
+++ b/kanawha-yaml/GSummersville_C.yml
@@ -50,11 +50,9 @@ geometries:
   GSummersville_C.g01:
     title: GauleySummersville_Existing
     roughness:
-      landuse:
-        description: National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022
+      landuse: baker_landuse
     precip_losses:
-      landuse:
-        description: National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022
+      landuse: baker_landuse
       soils: ssurgo
     structures: wv_clearinghouse
     mesh2d:
@@ -78,7 +76,7 @@ plans:
     geom: g01
     title: Unsteady_MultiHazard_Nov2003
     hydrographs:
-      - from_streamgage: "?USACE" # Summersville Lake / USACE
+      - from_streamgage: "USACE_Summersville_Lake" # Summersville Lake / USACE
         hydrograph_type: "Stage"
         start_datetime: 1/1/1985 11:00
         end_datetime:   12/31/2021 11:00
@@ -88,7 +86,7 @@ plans:
         r2: 0.90
         event: nov_2003
 
-      - from_streamgage: 01389100 # Gauley River Near Craigsville, WV
+      - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: "Stage"
         start_datetime: 12/1/1994 00:30
         end_datetime:   7/31/2016 22:30
@@ -153,7 +151,7 @@ plans:
     geom: g01
     title: Unsteady_MultiHazard_Jun2016
     hydrographs:
-      - from_streamgage: "?USACE" # Summersville Lake / USACE
+      - from_streamgage: "USACE_Summersville_Lake" # Summersville Lake / USACE
         hydrograph_type: Stage
         start_datetime: 1/1/1985 11:00
         end_datetime:   12/31/2021 11:00
@@ -243,7 +241,7 @@ plans:
     geom: g01
     title: Unsteady_MultiHazard_Jan1995
     hydrographs:
-      - from_streamgage: "?USACE" # Summersville Lake / USACE
+      - from_streamgage: "USACE_Summersville_Lake" # Summersville Lake / USACE
         hydrograph_type: Stage
         start_datetime: 1/1/1985 11:00
         end_datetime:   12/31/2021 11:00
@@ -293,7 +291,7 @@ plans:
     geom: g01
     title: Unsteady_MultiHazard_Jan1996
     hydrographs:
-      - from_streamgage: "?USACE" # Summersville Lake / USACE
+      - from_streamgage: "USACE_Summersville_Lake" # Summersville Lake / USACE
         hydrograph_type: Stage
         start_datetime: 1/1/1985 11:00
         end_datetime:   12/31/2021 11:00

--- a/kanawha-yaml/GSummersville_C.yml
+++ b/kanawha-yaml/GSummersville_C.yml
@@ -5,8 +5,10 @@ modified: 10/25/2022 20:07
 creators:
   - name:  Daniyal Siddiqui 
     email: daniyal.siddiqui@mbakerintl.com
+    org: baker
   - name:  Mark McBroom
     email: mmcbroom@mbakerintl.com
+    org: baker
 flows:
   GSummersville_C.u03:
     title: GauleeSummersville_FloodPlain_Nov2003
@@ -15,6 +17,7 @@ flows:
       start_datetime: 11/6/2003 13:00
       end_datetime:   11/28/2003 12:00
       spatially_varied: true
+      event: nov_2003
 
   GSummersville_C.u04:
     title: GauleeSummersville_FloodPlain_Jun2016
@@ -23,14 +26,16 @@ flows:
       start_datetime: 6/20/2016 13:00
       end_datetime:   7/4/2016 12:00
       spatially_varied: true
+      event: jun_2016
 
   GSummersville_C.u05:
     title: GauleeSummersville_FloodPlain_Jan1995
     hyetograph:
-      description: January 1996 excess precipitation. USACE-provided HMS excess precip to include snowmelt runoff.
-      start_datetime: 1/14/1996 13:00
-      end_datetime:   2/7/1996 10:00
+      description: January 1995 applied precipitation, provided by USACE
+      start_datetime: 1/5/1995 13:00
+      end_datetime:   1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
 
   GSummersville_C.u06:
     title: GauleeSummersville_FloodPlain_Jan1996
@@ -39,6 +44,7 @@ flows:
       start_datetime: 1/14/1996 13:00
       end_datetime:   2/7/1996 10:00
       spatially_varied: true
+      event: jan_1996
 
 geometries:
   GSummersville_C.g01:
@@ -80,6 +86,7 @@ plans:
         rsr: 0.35
         pbias: 0.03
         r2: 0.90
+        event: nov_2003
 
       - from_streamgage: 01389100 # Gauley River Near Craigsville, WV
         hydrograph_type: "Stage"
@@ -89,6 +96,7 @@ plans:
         rsr: 0.53
         pbias: 0.05
         r2: 0.86
+        event: nov_2003
 
       - from_streamgage: 03187000 # Gauley River at Camden ON Gauley, WV
         hydrograph_type: Stage
@@ -98,6 +106,7 @@ plans:
         rsr: 0.29
         pbias: 0.01
         r2: 0.92
+        event: nov_2003
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Stage
@@ -107,6 +116,7 @@ plans:
         rsr: 0.59
         pbias: -0.02
         r2: 0.89
+        event: nov_2003
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Flow
@@ -116,6 +126,7 @@ plans:
         rsr: 0.44
         pbias: 41.4
         r2: 0.88
+        event: nov_2003
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Flow
@@ -125,6 +136,7 @@ plans:
         rsr: 0.45
         pbias: 50.39
         r2: 0.88
+        event: nov_2003
 
       - from_streamgage: 03186500 # Williams River at Dyer, WV
         hydrograph_type: Flow
@@ -134,6 +146,7 @@ plans:
         rsr: 0.35
         pbias: 32.56
         r2: 0.95
+        event: nov_2003
   GSummersville_C.p03:
     description: null
     flow: u04
@@ -148,6 +161,7 @@ plans:
         rsr: 0.35
         pbias: 0.28
         r2: 0.99
+        event: jun_2016
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Stage
@@ -157,6 +171,7 @@ plans:
         rsr: 0.41
         pbias: 0.01
         r2: 0.86
+        event: jun_2016
 
       - from_streamgage: 03187000 # Gauley River at Camden ON Gauley, WV
         hydrograph_type: Stage
@@ -166,6 +181,7 @@ plans:
         rsr: 0.54
         pbias: 0.05
         r2: 0.74
+        event: jun_2016
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Stage
@@ -175,6 +191,7 @@ plans:
         rsr: 1.00
         pbias: -0.06
         r2: 0.77
+        event: jun_2016
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Flow
@@ -184,6 +201,7 @@ plans:
         rsr: 0.29
         pbias: 18.49
         r2: 0.93
+        event: jun_2016
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Flow
@@ -193,6 +211,7 @@ plans:
         rsr: 0.52
         pbias: 17.55
         r2: 0.82
+        event: jun_2016
 
       - from_streamgage: 03186500 # Williams River at Dyer, WV
         hydrograph_type: Flow
@@ -202,6 +221,7 @@ plans:
         rsr: 0.25
         pbias: 14.03
         r2: 0.94
+        event: jun_2016
 
       - from_streamgage: 03188900 # Laurel Creek Near Fenwick, WV
         hydrograph_type: Flow
@@ -211,6 +231,7 @@ plans:
         rsr: 0.34
         pbias: 15.99
         r2: 0.89
+        event: jun_2016
   GSummersville_C.p04:
     description: null
     flow: u03
@@ -230,6 +251,7 @@ plans:
         rsr: 1.86
         pbias: 0.41
         r2: 0.82
+        event: jan_1995
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Stage
@@ -239,6 +261,7 @@ plans:
         rsr: 0.71
         pbias: 0.03
         r2: 0.77
+        event: jan_1995
 
       - from_streamgage: 03187000 # Gauley River at Camden ON Gauley, WV
         hydrograph_type: Stage
@@ -248,6 +271,7 @@ plans:
         rsr: 1.00
         pbias: 0.06
         r2: 0.57
+        event: jan_1995
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Stage
@@ -257,6 +281,7 @@ plans:
         rsr: 1.01
         pbias: -0.03
         r2: 0.73
+        event: jan_1995
   GSummersville_C.p06:
     description: null
     flow: u05
@@ -276,6 +301,7 @@ plans:
         rsr: 1.10
         pbias: 1.40
         r2: 0.64
+        event: jan_1996
 
       - from_streamgage: 03189100 # Gauley River Near Craigsville, WV
         hydrograph_type: Stage
@@ -285,6 +311,7 @@ plans:
         rsr: 0.67
         pbias: -0.04
         r2: 0.73
+        event: jan_1996
 
       - from_streamgage: 03187000 # Gauley River at Camden ON Gauley, WV
         hydrograph_type: Stage
@@ -294,6 +321,7 @@ plans:
         rsr: 0.71
         pbias: -0.06
         r2: 0.66
+        event: jan_1996
 
       - from_streamgage: 03187500 # Cranberry River Near Richwood, WV
         hydrograph_type: Stage
@@ -303,4 +331,5 @@ plans:
         rsr: 1.59
         pbias: -0.08
         r2: 0.70
+        event: jan_1996
 title: GauleySummersville_BLE-C_FEMA

--- a/kanawha-yaml/GauleyLower.yml
+++ b/kanawha-yaml/GauleyLower.yml
@@ -2,8 +2,10 @@ description: ''
 creators:
   - name:  John Capobianco
     email: John.Capobianco@mbakerintl.com
+    org: baker
   - name:  Mark McBroom
     email: mmcbroom@mbakerintl.com
+    org: baker
 flows:
   GauleyLower_BLE_FEM.u01:
     title: GauleyLower_Floodplain_Nov2003
@@ -12,6 +14,7 @@ flows:
       start_datetime: 2003-11-06 00:00:00
       end_datetime:   2003-11-23 00:00:00
       spatially_varied: true
+      event: nov_2003
 
   GauleyLower_BLE_FEM.u02:
     title: GauleyLower_Floodplain_Jun2016
@@ -20,6 +23,7 @@ flows:
       start_datetime: 2016-06-20 12:00:00
       end_datetime:   2016-06-20 00:00:00
       spatially_varied: true
+      event: jun_2016
 
   GauleyLower_BLE_FEM.u03:
     title: GauleyLower_FloodPlain_Jan1995
@@ -28,6 +32,7 @@ flows:
       start_datetime: 1995-01-05 12:00:00
       end_datetime:   1995-01-23 12:00:00
       spatially_varied: true
+      event: jan_1995
 
   GauleyLower_BLE_FEM.u04:
     title: GauleyLower_FloodPlain_Jan1996
@@ -36,6 +41,7 @@ flows:
       start_datetime: 1996-01-14 00:00:00
       end_datetime:   1996-01-22 00:00:00
       spatially_varied: true
+      event: jan_1996
 
 geometries:
   GauleyLower_BLE_FEM.g01:
@@ -76,6 +82,7 @@ plans:
         rsr:    0.653
         pbias:  1.181
         r2:     0.607
+        event: nov_2003
 
       - start_datetime: 2003-09-30 00:00:00
         end_datetime:   2003-12-31 00:00:00
@@ -85,6 +92,7 @@ plans:
         rsr:    0.638
         pbias:  16.551
         r2:     0.666
+        event: nov_2003
 
       - start_datetime: 1994-12-01 05:00:00
         end_datetime:   2016-09-01 05:00:00
@@ -94,6 +102,7 @@ plans:
         rsr:    0.612
         pbias:  -0.182
         r2:     0.784
+        event: nov_2003
   GauleyLower_BLE_FEM.p02:
     description: null
     flow: u03
@@ -108,6 +117,7 @@ plans:
         rsr:    0.218
         pbias:  -1.5726
         r2:     0.962
+        event: jan_1995
 
       - start_datetime: 1994-12-01 05:00:00
         end_datetime:   2016-08-01 05:00:00
@@ -117,6 +127,8 @@ plans:
         rsr:    0.715
         pbias:  -0.195
         r2:     0.959
+        event: jan_1995
+
   GauleyLower_BLE_FEM.p03:
     description: null
     flow: u02
@@ -131,6 +143,7 @@ plans:
         rsr:    0.577
         pbias:  12.6
         r2:     0.670
+        event: jun_2016
 
       - start_datetime: 2016-04-30 00:00:00
         end_datetime:   2016-07-31 23:45:00
@@ -140,6 +153,7 @@ plans:
         rsr:    0.295
         pbias:  1.5
         r2:     0.918
+        event: jun_2016
 
       - start_datetime: 1994-12-01 05:00:00
         end_datetime:   2016-08-01 05:00:00
@@ -149,6 +163,7 @@ plans:
         rsr:    0.467
         pbias:  -0.201
         r2:     0.876
+        event: jun_2016
 
       - start_datetime: 2012-08-30 10:30:00
         end_datetime:   2022-06-26 23:30:00
@@ -158,6 +173,7 @@ plans:
         rsr:    0.376
         pbias:  -11.652
         r2:     0.878
+        event: jun_2016
 
       - start_datetime: 2009-08-31 15:00:00
         end_datetime:   2016-08-01 05:00:00
@@ -167,6 +183,7 @@ plans:
         rsr:    0.556
         pbias:  0.031
         r2:     0.896
+        event: jun_2016
 
       - start_datetime: 2014-04-02 18:00:00
         end_datetime:   2016-08-01 05:00:00
@@ -176,6 +193,7 @@ plans:
         rsr:    0.2959
         pbias:  -0.074
         r2:     0.953
+        event: jun_2016
   GauleyLower_BLE_FEM.p06:
     description: null
     flow: u04
@@ -190,6 +208,7 @@ plans:
         rsr:    0.593
         pbias:  24.806
         r2:     0.785
+        event: jan_1996
         
       - start_datetime: 1994-12-01 05:00:00
         end_datetime:   2016-08-01 05:00:00
@@ -199,4 +218,6 @@ plans:
         rsr:    0.415
         pbias:  -0.096
         r2:     0.875
+        event: jan_1996
+
 title: GauleyLower_BLE-C_FEMA

--- a/kanawha-yaml/GauleyLower.yml
+++ b/kanawha-yaml/GauleyLower.yml
@@ -47,11 +47,9 @@ geometries:
   GauleyLower_BLE_FEM.g01:
     title: Gauley_Lower
     roughness:
-      landuse:
-        description: National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022
+      landuse: baker_landuse
     precip_losses:
-      landuse:
-        description: National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022
+      landuse: baker_landuse
       soils: ssurgo
     structures: wv_clearinghouse
     terrain:

--- a/kanawha-yaml/GauleyLower.yml
+++ b/kanawha-yaml/GauleyLower.yml
@@ -51,7 +51,7 @@ geometries:
     precip_losses:
       landuse: baker_landuse
       soils: ssurgo
-    structures: wv_clearinghouse
+    structures: wv_clearinghouse_structures
     terrain:
       modifications:
         description: Cuts made through road and dam/berm embankments.

--- a/kanawha-yaml/Greenbrier_G7.yml
+++ b/kanawha-yaml/Greenbrier_G7.yml
@@ -57,12 +57,10 @@ geometries:
   Greenbrier_G7.g01:
     title: Greenbrier_G7_LiDAR
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -79,12 +77,10 @@ geometries:
   Greenbrier_G7.g02:
     title: LiDAR_G7_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -101,8 +97,7 @@ geometries:
   Greenbrier_G7.g03:
     title: LiDAR_G7_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse:  wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/Greenbrier_G7.yml
+++ b/kanawha-yaml/Greenbrier_G7.yml
@@ -63,8 +63,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -83,8 +82,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -101,8 +99,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/Greenbrier_G7.yml
+++ b/kanawha-yaml/Greenbrier_G7.yml
@@ -2,10 +2,13 @@ description: '2D rain-on-mesh BLE model of the 7th of nine Greenbrier River basi
 creators:
   - name: Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name: Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name: Dami George
     email: dami.george@wsp.com
+    org: wsp
 flows:
   Greenbrier_G7.u01:
     title: JAN1995 IC
@@ -14,36 +17,42 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
   Greenbrier_G7.u03:
     title: NOV2003 IC
     hyetograph:
       description: Gridded precipitation data from the November 2003 event
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
+      event: nov_2003
   Greenbrier_G7.u04:
     title: JUN2016 Cal
     hyetograph:
       description: Gridded precipitation data from the June 2016 event
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
+      event: jun_2016
   Greenbrier_G7.u05:
     title: JAN1995 Cal
     hyetograph:
       description: Gridded precipitation data from the January 1995 event
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
+      event: jan_1995
   Greenbrier_G7.u06:
     title: JAN1996 Cal
     hyetograph:
       description: Gridded precipitation data from the January 1996 event
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
+      event: jan_1996
   Greenbrier_G7.u07:
     title: NOV2003 Cal
     hyetograph:
       description: Gridded precipitation data from the November 2003 event
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
+      event: nov_2003
 geometries:
   Greenbrier_G7.g01:
     title: Greenbrier_G7_LiDAR

--- a/kanawha-yaml/Greenbrier_G8.yml
+++ b/kanawha-yaml/Greenbrier_G8.yml
@@ -75,8 +75,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -95,8 +94,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -113,8 +111,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/Greenbrier_G8.yml
+++ b/kanawha-yaml/Greenbrier_G8.yml
@@ -2,10 +2,13 @@ description: '2D rain-on-mesh BLE model of the 8th of nine Greenbrier River basi
 creators:
   - name:  Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name:  Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name:  Sirui Wen
     email: sirui.wen@wsp.com
+    org: wsp
 connected_models:
   - model: Greenbrier_G7.prj
     direction: upstream
@@ -19,6 +22,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
   Greenbrier_G8.u02:
     title: JAN1996
   Greenbrier_G8.u03:
@@ -28,6 +32,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
   Greenbrier_G8.u04:
     title: JUN2016 Calibration
     hyetograph:
@@ -35,6 +40,7 @@ flows:
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
       spatially_varied: true
+      event: jun_2016
   Greenbrier_G8.u05:
     title: JAN1995 Cal
     hyetograph:
@@ -42,6 +48,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
   Greenbrier_G8.u06:
     title: JAN1996 Cal
     hyetograph:
@@ -49,6 +56,7 @@ flows:
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
       spatially_varied: true
+      event: jan_1996
   Greenbrier_G8.u07:
     title: NOV2003 Cal
     hyetograph:
@@ -56,6 +64,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
 geometries:
   Greenbrier_G8.g01:
     title: Greenbrier_G8_LiDAR
@@ -146,6 +155,7 @@ plans:
         rsr: 0.37249
         pbias: 22.797
         r2: 0.90781
+        event: jun_2016
   Greenbrier_G8.p05:
     description: null
     flow: u05
@@ -160,6 +170,7 @@ plans:
         rsr: 1.6907
         pbias: 40.89
         r2: 0.42492
+        event: jan_1995
   Greenbrier_G8.p06:
     description: null
     flow: u06
@@ -174,6 +185,7 @@ plans:
         rsr: 1.3993
         pbias: 58.67
         r2: 0.54692
+        event: jan_1996
   Greenbrier_G8.p07:
     description: null
     flow: u07
@@ -188,4 +200,5 @@ plans:
         rsr: 0.49232
         pbias: 30.033
         r2: 0.9363
+        event: nov_2003
 title: Greenbrier_G8

--- a/kanawha-yaml/Greenbrier_G8.yml
+++ b/kanawha-yaml/Greenbrier_G8.yml
@@ -69,12 +69,10 @@ geometries:
   Greenbrier_G8.g01:
     title: Greenbrier_G8_LiDAR
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -91,12 +89,10 @@ geometries:
   Greenbrier_G8.g02:
     title: LiDAR_G8_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -113,8 +109,7 @@ geometries:
   Greenbrier_G8.g03:
     title: LiDAR_G8_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/Kanawha_G1.yml
+++ b/kanawha-yaml/Kanawha_G1.yml
@@ -6,10 +6,13 @@ connected_models:
 creators:
   - name: Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name: Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name: Julianna Villa
     email: julianna.villa@wsp.com
+    org: wsp
 flows:
   Kanawha_G1.u01:
     title: Jan-1995 Initial Conditions
@@ -18,6 +21,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
 
   Kanawha_G1.u02:
     title: Jan-1996 Initial Conditions
@@ -25,6 +29,7 @@ flows:
       description: Gridded precipitation data from the January 1996 event
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
+      event: jan_1996
 
   Kanawha_G1.u03:
     title: Nov-2003 Initial Conditions
@@ -32,6 +37,7 @@ flows:
       description: Gridded precipitation data from the November 2003 event
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
+      event: nov_2003
 
   Kanawha_G1.u04:
     title: Jun-2016 Initial Conditions
@@ -39,6 +45,7 @@ flows:
       description: Gridded precipitation data from the June 2016 event
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
+      event: jun_2016
 
   Kanawha_G1.u05:
     title: Jan-1995 Calibration
@@ -46,6 +53,7 @@ flows:
       description: Gridded precipitation data from the January 1995 event
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
+      event: jan_1995
 
   Kanawha_G1.u06:
     title: Jan-1996 Calibration
@@ -53,6 +61,7 @@ flows:
       description: Gridded precipitation data from the January 1996 event
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
+      event: jan_1996
 
   Kanawha_G1.u07:
     title: Nov-2003 Calibration
@@ -60,6 +69,7 @@ flows:
       description: Gridded precipitation data from the November 2003 event
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
+      event: nov_2003
 
   Kanawha_G1.u08:
     title: Jun-2016 Calibration
@@ -67,6 +77,7 @@ flows:
       description: Gridded precipitation data from the June 2016 event
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
+      event: jun_2016
 
 geometries:
   Kanawha_G1.g01:
@@ -168,6 +179,7 @@ plans:
         rsr: 1.0849
         pbias: 32.361
         r2: 0.89384
+        event: jan_1995
   Kanawha_G1.p06:
     description: null
     flow: u06
@@ -182,6 +194,7 @@ plans:
         rsr: 0.75269
         pbias: 22.303
         r2: 0.9242
+        event: jan_1996
   Kanawha_G1.p07:
     description: null
     flow: u07
@@ -196,6 +209,7 @@ plans:
         rsr: 0.82889
         pbias: 31.036
         r2: 0.81655
+        event: nov_2003
   Kanawha_G1.p08:
     description: null
     flow: u08
@@ -210,4 +224,5 @@ plans:
         rsr: 0.73549
         pbias: 26.618
         r2: 0.73227
+        event: jun_2016
 title: Kanawha_G1

--- a/kanawha-yaml/Kanawha_G1.yml
+++ b/kanawha-yaml/Kanawha_G1.yml
@@ -89,8 +89,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -109,8 +108,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -127,8 +125,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/Kanawha_G1.yml
+++ b/kanawha-yaml/Kanawha_G1.yml
@@ -83,12 +83,10 @@ geometries:
   Kanawha_G1.g01:
     title: LiDAR_G1
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -105,12 +103,10 @@ geometries:
   Kanawha_G1.g02:
     title: LiDAR_G1_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -127,8 +123,7 @@ geometries:
   Kanawha_G1.g03:
     title: LiDAR_G1_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/Kanawha_G2.yml
+++ b/kanawha-yaml/Kanawha_G2.yml
@@ -93,12 +93,10 @@ geometries:
   Kanawha_G2.g01:
     title: LiDAR_G2
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -115,12 +113,10 @@ geometries:
   Kanawha_G2.g02:
     title: LiDAR_G2_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -137,8 +133,7 @@ geometries:
   Kanawha_G2.g03:
     title: LiDAR_G2_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/Kanawha_G2.yml
+++ b/kanawha-yaml/Kanawha_G2.yml
@@ -9,10 +9,13 @@ modified: 11/14/2022 18:59
 creators:
   - name: Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name: Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name: Julianna Villa
     email: julianna.villa@wsp.com
+    org: wsp
 flows:
   Kanawha_G2.u01:
     title: Jan-1995 Initial Conditions
@@ -21,6 +24,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
 
   Kanawha_G2.u02:
     title: Jan-1996 Initial Conditions
@@ -29,6 +33,7 @@ flows:
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
       spatially_varied: true
+      event: jan_1996
 
   Kanawha_G2.u03:
     title: Nov-2003 Initial Conditions
@@ -37,6 +42,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
 
   Kanawha_G2.u04:
     title: Jun-2016 Initial Conditions
@@ -45,6 +51,7 @@ flows:
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
       spatially_varied: true
+      event: jun_2016
 
   Kanawha_G2.u05:
     title: Jan-1995 Calibration
@@ -53,6 +60,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
 
   Kanawha_G2.u06:
     title: Jan-1996 Calibration
@@ -61,6 +69,7 @@ flows:
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
       spatially_varied: true
+      event: jan_1996
 
   Kanawha_G2.u07:
     title: Nov-2003 Calibration
@@ -69,6 +78,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
 
   Kanawha_G2.u08:
     title: Jun-2016 Calibration
@@ -77,6 +87,7 @@ flows:
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
       spatially_varied: true
+      event: jun_2016
 
 geometries:
   Kanawha_G2.g01:

--- a/kanawha-yaml/Kanawha_G2.yml
+++ b/kanawha-yaml/Kanawha_G2.yml
@@ -99,8 +99,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -119,8 +118,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -137,8 +135,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/New-LittleRiver.yml
+++ b/kanawha-yaml/New-LittleRiver.yml
@@ -2,8 +2,10 @@ description: ''
 creators:
   - name: Ryan Pohl
     email: ryan.pohl@aecom.com
+    org: aecom
   - name: Reuben Cozmyer
     email: reuben.cozmyer@aecom.com
+    org: aecom
 ras_version: 6.3.0
 modified: 1/25/2023 23:59
 flows:
@@ -13,18 +15,21 @@ flows:
       description: June 2016 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 6/20/2016 12:00
       end_datetime:   7/4/2016 00:00
+      event: jun_2016
   New-LittleRiver.u07:
     title: JAN1996_HMS
     hyetograph:
       description: January 1996 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 1/14/1996 12:00
       end_datetime:   2/7/1996 12:00
+      event: jan_1996
   New-LittleRiver.u08:
     title: NOV2003_HMS
     hyetograph:
       description: November 2003 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 11/6/2003 12:00
       end_datetime:   11/28/2003 12:00
+      event: nov_2003
   New-LittleRiver.u09:
     title: restart_file
     hyetograph:
@@ -32,12 +37,14 @@ flows:
       start_datetime: 11/18/2003 00:00
       end_datetime:   11/22/2003 00:00
       spatially_varied: false
+      event: nov_2003
   New-LittleRiver.u10:
     title: JAN1995_HMS
     hyetograph:
       description: January 1995 gridded excess precipitation, from HEC-HMS in HEC-DSS format
       start_datetime: 1/5/1995 14:00
       end_datetime:   1/29/1995 11:00
+      event: jan_1995
 geometries:
   New-LittleRiver.g01:
     title: New_Little_River
@@ -70,6 +77,7 @@ plans:
         rsr:   1.14
         pbias: 19.55
         r2: 0.01
+        event: jun_2016
 
       - from_streamgage: "03170000"
         hydrograph_type: Stage
@@ -79,6 +87,7 @@ plans:
         rsr:   0.81
         pbias: 14.11
         r2: 0.64
+        event: jun_2016
 
   New-LittleRiver.p06:
     description: "with rating curve at dam and initial condition\nbigger channels\
@@ -96,6 +105,7 @@ plans:
         rsr:   0.79
         pbias: 9.42
         r2: 0.39
+        event: nov_2003
 
       - from_streamgage: "03170000"
         hydrograph_type: Stage
@@ -105,6 +115,7 @@ plans:
         rsr:   0.25
         pbias: 5.13
         r2:    0.94
+        event: nov_2003
 
   New-LittleRiver.p07:
     description: null
@@ -120,6 +131,7 @@ plans:
         rsr:   0.66
         pbias: 1.31
         r2:    0.56
+        event: jan_1996
 
       - from_streamgage: "03170000"
         hydrograph_type: Stage
@@ -129,6 +141,7 @@ plans:
         rsr:   0.32
         pbias: -2.86
         r2:    0.95
+        event: jan_1996
 
   New-LittleRiver.p17:
     description: null
@@ -150,6 +163,7 @@ plans:
         rsr:   0.65
         pbias: 9.25
         r2:    0.58
+        event: jan_1995
 
       - from_streamgage: "03170000"
         hydrograph_type: Stage
@@ -159,5 +173,6 @@ plans:
         rsr:   0.22
         pbias: -5.96
         r2:    0.96
+        event: jan_1995
 
 title: New-Little River

--- a/kanawha-yaml/UpperKanawha.yml
+++ b/kanawha-yaml/UpperKanawha.yml
@@ -14,10 +14,13 @@ description: 'Watershed: Upper Kanawha River
 creators:
   - name:  Dawit Zeweldi
     email: Dawit.Zeweldi@freese.com
+    org: freese
   - name:  Andrew Swynenberg
     email: Andrew.Swynenberg@freese.com
+    org: freese
   - name:  Matt Lewis
     email: Matt.Lewis@freese.com
+    org: freese
 flows:
   UpperKanawha.u01:
     title: Jan1996
@@ -27,6 +30,7 @@ flows:
       start_datetime: 1996-01-17 06:00:00
       end_datetime:   1996-02-04 06:00:00
       spatially_varied: true
+      event: jan_1996
 
   UpperKanawha.u02:
     title: Jan1996_InitialConditions
@@ -35,6 +39,7 @@ flows:
       start_datetime: 1996-01-15 00:00:00
       end_datetime:   1996-01-17 06:00:00
       spatially_varied: true
+      event: jan_1996
 
   UpperKanawha.u07:
     title: Nov2003_InitialConditions
@@ -43,6 +48,7 @@ flows:
       start_datetime: 2003-11-03 00:00:00
       end_datetime:   2003-11-12 00:00:00
       spatially_varied: true
+      event: nov_2003
 
   UpperKanawha.u08:
     title: Nov2003
@@ -51,6 +57,7 @@ flows:
       start_datetime: 2003-11-12 00:00:00
       end_datetime:   2003-11-24 00:00:00
       spatially_varied: true
+      event: nov_2003
 
   UpperKanawha.u09:
     title: Jun2016_InitialConditions
@@ -59,6 +66,7 @@ flows:
       start_datetime: 2016-06-07 00:00:00
       end_datetime:   2016-06-22 00:00:00
       spatially_varied: true
+      event: jun_2016
 
   UpperKanawha.u11:
     title: Jun2016
@@ -67,6 +75,7 @@ flows:
       start_datetime: 2016-06-22 00:00:00
       end_datetime:   2016-06-28 00:00:00
       spatially_varied: true
+      event: jun_2016
 geometries:
   UpperKanawha.g01:
     title: UpperKanawha
@@ -113,6 +122,7 @@ plans:
         rsr:    13.48
         pbias:  -0.2696
         r2:     0.0079179
+        event: jun_2016
 
       - start_datetime: 2016-06-22 00:00:00
         end_datetime:   2016-06-28 00:00:00
@@ -123,6 +133,7 @@ plans:
         rsr:    0.19255
         pbias:  -0.13638
         r2:     0.98229
+        event: jun_2016
 
       - start_datetime: 2016-06-22 00:00:00
         end_datetime:   2016-06-28 00:00:00
@@ -133,6 +144,7 @@ plans:
         rsr:    0.7485
         pbias:  0.07278
         r2:     0.57783
+        event: jun_2016
 
       - start_datetime: 2016-06-22 00:00:00
         end_datetime:   2016-06-28 00:00:00
@@ -143,6 +155,7 @@ plans:
         rsr:    0.28112
         pbias:  0.12004
         r2:     0.92979
+        event: jun_2016
 
   UpperKanawha.p02:
     description: "Geometry: Upper Kanawha BLE geometry. Includes Marmet and London\
@@ -163,6 +176,7 @@ plans:
         rsr:    7.1759
         pbias:  -0.18653
         r2:     0.22156
+        event: nov_2003
 
       - start_datetime: 2003-11-12 00:00:00
         end_datetime:   2003-11-24 00:00:00
@@ -173,6 +187,7 @@ plans:
         rsr:    0.23567
         pbias:  -0.14871
         r2:     0.98069
+        event: nov_2003
 
       - start_datetime: 2003-11-12 00:00:00
         end_datetime:   2003-11-24 00:00:00
@@ -183,6 +198,7 @@ plans:
         rsr:    0.41071
         pbias:  0.023509
         r2:     0.92922
+        event: nov_2003
 
       - start_datetime: 2003-11-12 00:00:00
         end_datetime:   2003-11-24 00:00:00
@@ -193,6 +209,7 @@ plans:
         rsr:    0.44465
         pbias:  0.061883
         r2:     0.8096
+        event: nov_2003
   UpperKanawha.p03:
     description: null
     flow: u09

--- a/kanawha-yaml/UpperKanawha.yml
+++ b/kanawha-yaml/UpperKanawha.yml
@@ -116,6 +116,7 @@ plans:
       - start_datetime: 2016-06-22 00:00:00
         end_datetime:   2016-06-28 00:00:00
         title: London L&D Pool
+        from_streamgage: USACE_London_LD_Pool
         description: Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration.
         hydrograph_type: "Stage"
         nse:    -180.7
@@ -127,6 +128,7 @@ plans:
       - start_datetime: 2016-06-22 00:00:00
         end_datetime:   2016-06-28 00:00:00
         title: London L&D Tailwater
+        from_streamgage: USACE_London_LD_Tailwater
         description: Stage hydrograph provided by USACE.
         hydrograph_type: "Stage"
         nse:    0.96292
@@ -138,6 +140,7 @@ plans:
       - start_datetime: 2016-06-22 00:00:00
         end_datetime:   2016-06-28 00:00:00
         title: Marmet L&D Pool 
+        from_streamgage: USACE_Marmet_LD_Pool
         description: Stage hydrograph provided by USACE.
         hydrograph_type: "Stage"
         nse:    0.43975
@@ -149,6 +152,7 @@ plans:
       - start_datetime: 2016-06-22 00:00:00
         end_datetime:   2016-06-28 00:00:00
         title: Marmet L&D Tailwater
+        from_streamgage: USACE_Marmet_LD_Tailwater
         description: Stage hydrograph provided by USACE.
         hydrograph_type: "Stage"
         nse:    0.92097
@@ -170,6 +174,7 @@ plans:
       - start_datetime: 2003-11-12 00:00:00
         end_datetime:   2003-11-24 00:00:00
         title: London L&D Pool
+        from_streamgage: USACE_London_LD_Pool
         description: Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration.
         hydrograph_type: "Stage"
         nse:    -50.493
@@ -181,6 +186,7 @@ plans:
       - start_datetime: 2003-11-12 00:00:00
         end_datetime:   2003-11-24 00:00:00
         title: London L&D Tailwater
+        from_streamgage: USACE_London_LD_Tailwater
         description: Stage hydrograph provided by USACE.
         hydrograph_type: "Stage"
         nse:    0.94446
@@ -192,6 +198,7 @@ plans:
       - start_datetime: 2003-11-12 00:00:00
         end_datetime:   2003-11-24 00:00:00
         title: Marmet L&D Pool 
+        from_streamgage: USACE_Marmet_LD_Pool
         description: Stage hydrograph provided by USACE.
         hydrograph_type: "Stage"
         nse:    0.83132
@@ -203,6 +210,7 @@ plans:
       - start_datetime: 2003-11-12 00:00:00
         end_datetime:   2003-11-24 00:00:00
         title: Marmet L&D Tailwater
+        from_streamgage: USACE_Marmet_LD_Tailwater
         description: Stage hydrograph provided by USACE.
         hydrograph_type: "Stage"
         nse:    0.80228

--- a/kanawha-yaml/UpperNew_Lower.yml
+++ b/kanawha-yaml/UpperNew_Lower.yml
@@ -2,8 +2,10 @@ description: '2D rain-on-mesh BLE model of the New River Basin in Wythe and Carr
 creators:
   - name: Elizabeth Vande Krol
     email: elizabeth.vandekrol@aecom.com
+    org: aecom
   - name: Reuben Cozmyer
     email: reuben.cozmyer@aecom.com
+    org: aecom
 ras_version: 6.3.1
 modified: 1/1/2023 13:15
 flows:
@@ -20,24 +22,28 @@ flows:
       description: Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)
       start_datetime: 1/5/1995 14:00
       end_datetime:   1/29/1995 12:00
+      event: jan_1995
   UpperNew_Lower.u03:
     title: Jan1996
     hyetograph:
       description: Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)
       start_datetime: 1/19/1996 5:00
       end_datetime:   2/2/1996 4:00
+      event: jan_1996
   UpperNew_Lower.u04:
     title: Nov2003
     hyetograph:
       description: Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)
       start_datetime: 11/6/2003 13:00
       end_datetime:   11/28/2003 10:00
+      event: nov_2003
   UpperNew_Lower.u05:
     title: Jun2016
     hyetograph:
       description: Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)
       start_datetime: 6/20/2016 13:00
       end_datetime:   7/4/2016 10:00
+      event: jun_2016
 geometries:
   UpperNew_Lower.g03:
     title: Simplified
@@ -78,6 +84,7 @@ plans:
         rsr:   0.276
         pbias: 3.959
         r2:    0.978
+        event: jan_1995
 
   UpperNew_Lower.p03:
     description: 'Start time had to change from 14JAN1996 1200 to 19JAN1996 0500 due
@@ -97,6 +104,7 @@ plans:
         rsr:   0.834
         pbias: 9.689
         r2:    0.326
+        event: jan_1996
   UpperNew_Lower.p04:
     description: null
     flow: u04
@@ -110,6 +118,7 @@ plans:
         rsr:   0.555
         pbias: 26.041
         r2:    0.984
+        event: nov_2003
 
       - from_streamgage: "03165500"
         start_datetime: 11/6/2003 13:00
@@ -118,6 +127,7 @@ plans:
         rsr:   0.48
         pbias: 7.498
         r2:    0.935
+        event: nov_2003
 
   UpperNew_Lower.p07:
     description: null
@@ -132,6 +142,7 @@ plans:
         rsr:   1.302
         pbias: 5.316
         r2:    0.049
+        event: jun_2016
 
       - from_streamgage: "03165500"
         start_datetime: 6/20/2016 13:00
@@ -140,4 +151,5 @@ plans:
         rsr:   0.723
         pbias: 0.42
         r2:    0.723
+        event: jun_2016
 title: UpperNew_Lower

--- a/kanawha-yaml/UpperNew_Upper.yml
+++ b/kanawha-yaml/UpperNew_Upper.yml
@@ -2,6 +2,7 @@ description: ''
 creators:
   - name: Michelle Terry
     email: michelle.terry@aecom.com
+    org: aecom
 ras_version: 6.3.1
 modified: 12/8/2022 13:17
 flows:
@@ -11,24 +12,28 @@ flows:
       description: Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)
       start_datetime: 1/11/1995 0:00
       end_datetime:   1/19/1995 0:00
+      event: jan_1995
   UpperNew_Upper.u02:
     title: Nov2003
     hyetograph:
       description: Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)
       start_datetime: 11/16/2003 0:00
       end_datetime: 11/23/2003 0:00
+      event: nov_2003
   UpperNew_Upper.u03:
     title: Jan1996
     hyetograph:
       description: Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)
       start_datetime: 1/15/1996 0:00
       end_datetime: 1/23/1996 0:00
+      event: jan_1996
   UpperNew_Upper.u04:
     title: Jun2016
     hyetograph:
       description: Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/3/2016 12:00
+      event: jun_2016
   UpperNew_Upper.u05:
     title: RestartFile
 geometries:
@@ -63,6 +68,7 @@ plans:
         rsr:   0.21
         pbias: -5.26
         r2:    0.97
+        event: jan_1995
 
       - from_streamgage: "03164000"
         start_datetime: 1/11/1995 0:00
@@ -71,6 +77,7 @@ plans:
         rsr:   0.34
         pbias: 20.77
         r2:    0.91
+        event: jan_1995
 
   UpperNew_Upper.p02:
     description: null
@@ -85,6 +92,7 @@ plans:
         rsr:   0.18
         pbias: -7.82
         r2:    0.97
+        event: nov_2003
       - from_streamgage: "03164000"
         start_datetime: 11/16/2003 0:00
         end_datetime:   11/23/2003 0:00
@@ -92,6 +100,7 @@ plans:
         rsr:   0.62
         pbias: 44.00
         r2:    0.80
+        event: nov_2003
   UpperNew_Upper.p03:
     description: null
     flow: u03
@@ -105,6 +114,7 @@ plans:
         rsr:   0.48
         pbias: -2.61
         r2:    0.79
+        event:  jan_1996
       - from_streamgage: "03164000"
         start_datetime: 1/15/1996 0:00
         end_datetime:   1/23/1996 0:00
@@ -112,6 +122,7 @@ plans:
         rsr:   1.16
         pbias: 56.75
         r2:    0.33
+        event:  jan_1996
   UpperNew_Upper.p04:
     description: null
     flow: u04
@@ -125,6 +136,7 @@ plans:
         rsr:   1.49
         pbias: -8.08
         r2:    0.02
+        event: jun_2016
       - from_streamgage: "03164000"
         start_datetime: 6/20/2016 12:00
         end_datetime:   7/3/2016 12:00
@@ -132,4 +144,5 @@ plans:
         rsr:   2.87
         pbias: 58.76
         r2:    0.14
+        event: jun_2016
 title: UpperNew_Upper

--- a/kanawha-yaml/WatershedG3.yml
+++ b/kanawha-yaml/WatershedG3.yml
@@ -66,8 +66,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -86,8 +85,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -104,8 +102,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/WatershedG3.yml
+++ b/kanawha-yaml/WatershedG3.yml
@@ -2,10 +2,13 @@ description: 2D rain-on-mesh BLE model of the third of nine Greenbrier River bas
 creators:
   - name: Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name: Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name: Jon Bartlotti
     email: jonathan.bartlotti@wsp.com
+    org: wsp
 modified: 11/14/2022 18:30
 connected_models:
   - model: Kanawha_G2.prj
@@ -20,6 +23,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
 
   WatershedG3.u02:
     title: Jan-1996
@@ -28,6 +32,7 @@ flows:
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
       spatially_varied: true
+      event: jan_1996
 
   WatershedG3.u03:
     title: Nov-2003
@@ -36,6 +41,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
 
   WatershedG3.u04:
     title: Jun-2016
@@ -44,6 +50,7 @@ flows:
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
       spatially_varied: true
+      event: jun_2016
 
   WatershedG3.u05:
     title: Jan-1995 IC
@@ -149,6 +156,7 @@ plans:
         rsr: 0.93227
         pbias: 35.16
         r2: 0.61693
+        event: jan_1995
 
   WatershedG3.p06:
     flow: u02
@@ -164,6 +172,7 @@ plans:
         rsr: 0.68716
         pbias: 35.098
         r2: 0.91635
+        event: jan_1996
 
   WatershedG3.p07:
     flow: u03
@@ -179,6 +188,7 @@ plans:
         rsr: 0.60257
         pbias: 45.403
         r2: 0.9099
+        event: nov_2003
 
   WatershedG3.p08:
     flow: u04
@@ -194,4 +204,5 @@ plans:
         rsr: 0.19314
         pbias: 13.292
         r2: 0.98257
+        event: jun_2016
 title: Watershed G3

--- a/kanawha-yaml/WatershedG3.yml
+++ b/kanawha-yaml/WatershedG3.yml
@@ -60,12 +60,10 @@ geometries:
   WatershedG3.g01:
     title: LiDAR
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -82,12 +80,10 @@ geometries:
   WatershedG3.g02:
     title: LiDAR_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -104,8 +100,7 @@ geometries:
   WatershedG3.g03:
     title: LiDAR_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/WatershedG4.yml
+++ b/kanawha-yaml/WatershedG4.yml
@@ -51,12 +51,10 @@ geometries:
   WatershedG4.g01:
     title: LiDAR
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -73,12 +71,10 @@ geometries:
   WatershedG4.g02:
     title: LiDAR_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -95,8 +91,7 @@ geometries:
   WatershedG4.g03:
     title: LiDAR_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/WatershedG4.yml
+++ b/kanawha-yaml/WatershedG4.yml
@@ -2,10 +2,13 @@ description: '2D rain-on-mesh BLE model of the fourth of nine Greenbrier River b
 creators:
   - name:  Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name:  Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name:  Jonathan Bartlotti
     email: jonathan.bartlotti@wsp.com
+    org: wsp
 connected_models:
   - model: WatershedG3.prj
     direction: upstream
@@ -19,6 +22,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
   WatershedG4.u02:
     title: Jan-1996
     hyetograph:
@@ -26,6 +30,7 @@ flows:
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
       spatially_varied: true
+      event: jan_1996
   WatershedG4.u03:
     title: Nov-2003
     hyetograph:
@@ -33,6 +38,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
   WatershedG4.u04:
     title: Jun-2016
     hyetograph:
@@ -40,6 +46,7 @@ flows:
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
       spatially_varied: true
+      event: jun_2016
 geometries:
   WatershedG4.g01:
     title: LiDAR

--- a/kanawha-yaml/WatershedG4.yml
+++ b/kanawha-yaml/WatershedG4.yml
@@ -57,8 +57,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -77,8 +76,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -95,8 +93,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/WatershedG9.yml
+++ b/kanawha-yaml/WatershedG9.yml
@@ -60,8 +60,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -80,8 +79,7 @@ geometries:
       landuse: wsp_landuse
       soils: ssurgo
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:
@@ -98,8 +96,7 @@ geometries:
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:
-      bathymetry:
-        description: Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area.
+      bathymetry: gb_bath
       modifications:
         description: Cuts made through road embankments.
     mesh2d:

--- a/kanawha-yaml/WatershedG9.yml
+++ b/kanawha-yaml/WatershedG9.yml
@@ -54,12 +54,10 @@ geometries:
   WatershedG9.g01:
     title: LiDAR
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 2003 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -76,12 +74,10 @@ geometries:
   WatershedG9.g02:
     title: LiDAR_2016
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Calibrated CN Losses for 1995 and 2016 storm event
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
       soils: ssurgo
     terrain:
       bathymetry:
@@ -98,8 +94,7 @@ geometries:
   WatershedG9.g03:
     title: LiDAR_1996
     roughness:
-      landuse: 
-        description: Custom land cover analysis of NAIP 2022 imagery
+      landuse: wsp_landuse
     precip_losses:
       description: Losses determined from USACE HEC-HMS model for 1996 event
     terrain:

--- a/kanawha-yaml/WatershedG9.yml
+++ b/kanawha-yaml/WatershedG9.yml
@@ -2,10 +2,13 @@ description: '2D rain-on-mesh BLE model of the ninth of nine Greenbrier River ba
 creators:
   - name:  Josh Hill
     email: josh.hill@wsp.com
+    org: wsp
   - name:  Ben Rufenacht
     email: ben.rufenacht@wsp.com
+    org: wsp
   - name:  Jonathan Bartlotti
     email: jonathan.bartlotti@wsp.com
+    org: wsp
 modified: 11/14/2022 19:26
 connected_models:
   - model: WatershedG8.prj
@@ -18,6 +21,7 @@ flows:
       start_datetime: 1/5/1995 12:00
       end_datetime: 1/29/1995 12:00
       spatially_varied: true
+      event: jan_1995
 
   WatershedG9.u02:
     title: Jan-1996
@@ -26,6 +30,7 @@ flows:
       start_datetime: 1/14/1996 12:00
       end_datetime: 2/7/1996 11:00
       spatially_varied: true
+      event: jan_1996
 
   WatershedG9.u03:
     title: Nov-2003
@@ -34,6 +39,7 @@ flows:
       start_datetime: 11/6/2003 12:00
       end_datetime: 11/28/2003 11:00
       spatially_varied: true
+      event: nov_2003
       
   WatershedG9.u04:
     title: Jun-2016
@@ -42,6 +48,7 @@ flows:
       start_datetime: 6/20/2016 12:00
       end_datetime: 7/4/2016 11:00
       spatially_varied: true
+      event: jun_2016
       
 geometries:
   WatershedG9.g01:
@@ -138,6 +145,7 @@ plans:
         rsr: 0.52275
         pbias: 28.095
         r2: 0.94184
+        event: jun_2016
   WatershedG9.p05:
     description: null
     flow: u01
@@ -152,6 +160,7 @@ plans:
         rsr: 1.5856
         pbias: 45.535
         r2: 0.90313
+        event: jan_1995
   WatershedG9.p06:
     description: null
     flow: u02
@@ -166,6 +175,7 @@ plans:
         rsr: 1.029
         pbias: 60.35
         r2: 0.83038
+        event: jan_1996
   WatershedG9.p07:
     description: null
     flow: u03
@@ -180,6 +190,7 @@ plans:
         rsr: 0.52275
         pbias: 28.095
         r2: 0.94184
+        event: nov_2003
   WatershedG9.p08:
     description: null
     flow: u04

--- a/kanawha.ttl
+++ b/kanawha.ttl
@@ -1,124 +1,105 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ffrd_orgs: <http://example.ffrd.fema.gov/orgs/> .
+@prefix ffrd_people: <http://example.ffrd.fema.gov/people/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix kanawha: <http://ffrd.fema.gov/models/kanawha/> .
+@prefix kanawha_events: <http://example.ffrd.fema.gov/kanawha/events/> .
+@prefix kanawha_models: <http://example.ffrd.fema.gov/kanawha/models/> .
 @prefix rascat: <http://www.example.org/rascat/0.1#> .
 @prefix usgs_gages: <https://waterdata.usgs.gov/monitoring-location/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-kanawha:BasinG6.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "dami.george@wsp.com" ;
-            foaf:name "Dami George" ],
-        [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ] ;
+kanawha_models:BasinG6.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Dami_George,
+        ffrd_people:Josh_Hill ;
     dcterms:description "2D rain-on-mesh BLE model of the 6th of nine Greenbrier River basins in south-central West Virginia." ;
     dcterms:title "BasinG6" ;
-    rascat:hasGeometry kanawha:BasinG6.g01,
-        kanawha:BasinG6.g02,
-        kanawha:BasinG6.g03 ;
-    rascat:hasPlan kanawha:BasinG6.p01,
-        kanawha:BasinG6.p02,
-        kanawha:BasinG6.p03,
-        kanawha:BasinG6.p04,
-        kanawha:BasinG6.p05,
-        kanawha:BasinG6.p06,
-        kanawha:BasinG6.p07,
-        kanawha:BasinG6.p08 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u01,
-        kanawha:BasinG6.u02,
-        kanawha:BasinG6.u03,
-        kanawha:BasinG6.u04,
-        kanawha:BasinG6.u05,
-        kanawha:BasinG6.u06,
-        kanawha:BasinG6.u07 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:BasinG6.g01,
+        kanawha_models:BasinG6.g02,
+        kanawha_models:BasinG6.g03 ;
+    rascat:hasPlan kanawha_models:BasinG6.p01,
+        kanawha_models:BasinG6.p02,
+        kanawha_models:BasinG6.p03,
+        kanawha_models:BasinG6.p04,
+        kanawha_models:BasinG6.p05,
+        kanawha_models:BasinG6.p06,
+        kanawha_models:BasinG6.p07,
+        kanawha_models:BasinG6.p08 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u01,
+        kanawha_models:BasinG6.u02,
+        kanawha_models:BasinG6.u03,
+        kanawha_models:BasinG6.u04,
+        kanawha_models:BasinG6.u05,
+        kanawha_models:BasinG6.u06,
+        kanawha_models:BasinG6.u07 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:BluestoneLocal.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "pete.williams@aecom.com" ;
-            foaf:name "Pete Williams" ] ;
+kanawha_models:BluestoneLocal.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Pete_Williams ;
     dcterms:description "" ;
     dcterms:modified "2022-10-25T23:59:00"^^xsd:dateTime ;
     dcterms:title "Bluestone Local - Compass 2D BLE" ;
-    rascat:hasGeometry kanawha:BluestoneLocal.g01 ;
-    rascat:hasPlan kanawha:BluestoneLocal.p01,
-        kanawha:BluestoneLocal.p02,
-        kanawha:BluestoneLocal.p03,
-        kanawha:BluestoneLocal.p04 ;
-    rascat:hasUnsteadyFlow kanawha:BluestoneLocal.u01,
-        kanawha:BluestoneLocal.u02,
-        kanawha:BluestoneLocal.u03,
-        kanawha:BluestoneLocal.u04 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
+    rascat:hasPlan kanawha_models:BluestoneLocal.p01,
+        kanawha_models:BluestoneLocal.p02,
+        kanawha_models:BluestoneLocal.p03,
+        kanawha_models:BluestoneLocal.p04 ;
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u01,
+        kanawha_models:BluestoneLocal.u02,
+        kanawha_models:BluestoneLocal.u03,
+        kanawha_models:BluestoneLocal.u04 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.0" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:Bluestone_Upper.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "kc.robinson@aecom.com" ;
-            foaf:name "KC Robinson" ],
-        [ a foaf:Person ;
-            foaf:mbox "ryan.pohl@aecom.com" ;
-            foaf:name "Ryan Phol" ] ;
+kanawha_models:Bluestone_Upper.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:KC_Robinson,
+        ffrd_people:Ryan_Phol ;
     dcterms:description "2D rain-on-mesh BLE model of the upper portion of the Bluestone River Basin near Princeton, West Virginia. INNOVATION PROJECT #2 - 2D RAS FFRD PILOT Technical Advisement to FY21 IRWA with USACE" ;
     dcterms:modified "2022-10-18T18:25:00"^^xsd:dateTime ;
     dcterms:title "Bluestone_Upper" ;
-    rascat:hasGeometry kanawha:Bluestone_Upper.g07 ;
-    rascat:hasPlan kanawha:Bluestone_Upper.p15,
-        kanawha:Bluestone_Upper.p16,
-        kanawha:Bluestone_Upper.p17,
-        kanawha:Bluestone_Upper.p18 ;
-    rascat:hasUnsteadyFlow kanawha:Bluestone_Upper.u06,
-        kanawha:Bluestone_Upper.u07,
-        kanawha:Bluestone_Upper.u08,
-        kanawha:Bluestone_Upper.u09 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
+    rascat:hasPlan kanawha_models:Bluestone_Upper.p15,
+        kanawha_models:Bluestone_Upper.p16,
+        kanawha_models:Bluestone_Upper.p17,
+        kanawha_models:Bluestone_Upper.p18 ;
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u06,
+        kanawha_models:Bluestone_Upper.u07,
+        kanawha_models:Bluestone_Upper.u08,
+        kanawha_models:Bluestone_Upper.u09 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:CoalRiver.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "courtney.fournier@aecom.com" ;
-            foaf:name "Courtney Fournier" ],
-        [ a foaf:Person ;
-            foaf:mbox "yacoub.raheem@aecom.com" ;
-            foaf:name "Yacoub Raheem" ] ;
+kanawha_models:CoalRiver.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Courtney_Fournier,
+        ffrd_people:Yacoub_Raheem ;
     dcterms:description "2D rain-on-mesh BLE model of the upper portion of the Bluestone River Basin near Princeton, West Virginia. INNOVATION PROJECT #2 - 2D RAS FFRD PILOT Technical Advisement to FY21 IRWA with USACE" ;
     dcterms:modified "2022-10-13T15:11:00"^^xsd:dateTime ;
     dcterms:title "CoalRiver" ;
-    rascat:hasGeometry kanawha:CoalRiver.g01 ;
-    rascat:hasPlan kanawha:CoalRiver.p01,
-        kanawha:CoalRiver.p02,
-        kanawha:CoalRiver.p03,
-        kanawha:CoalRiver.p04 ;
-    rascat:hasUnsteadyFlow kanawha:CoalRiver.u01,
-        kanawha:CoalRiver.u02,
-        kanawha:CoalRiver.u03,
-        kanawha:CoalRiver.u04 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
+    rascat:hasPlan kanawha_models:CoalRiver.p01,
+        kanawha_models:CoalRiver.p02,
+        kanawha_models:CoalRiver.p03,
+        kanawha_models:CoalRiver.p04 ;
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u01,
+        kanawha_models:CoalRiver.u02,
+        kanawha_models:CoalRiver.u03,
+        kanawha_models:CoalRiver.u04 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:ElkMiddle.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "kevan.leelum@wsp.com" ;
-            foaf:name "Kevan Lee Lum" ],
-        [ a foaf:Person ;
-            foaf:mbox "britton.wells@wsp.com" ;
-            foaf:name "Britton Wells" ],
-        [ a foaf:Person ;
-            foaf:mbox "masoud.meshkat@wsp.com" ;
-            foaf:name "Masoud Meshkat" ] ;
+kanawha_models:ElkMiddle.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Britton_Wells,
+        ffrd_people:Kevan_Lee_Lum,
+        ffrd_people:Masoud_Meshkat ;
     dcterms:description """Elk Middle watershed, Kanawha Basin, WV
 INNOVATION PROJECT #2 - 2D RAS FFRD PILOT
 Technical Advisement to FY21 IRWA with USACE
@@ -133,305 +114,253 @@ Version: Model Setup
 """ ;
     dcterms:modified "2022-10-19T19:55:00"^^xsd:dateTime ;
     dcterms:title "ElkMiddle" ;
-    rascat:hasGeometry kanawha:ElkMiddle.g01,
-        kanawha:ElkMiddle.g02 ;
-    rascat:hasPlan kanawha:ElkMiddle.p01,
-        kanawha:ElkMiddle.p03,
-        kanawha:ElkMiddle.p04,
-        kanawha:ElkMiddle.p06 ;
-    rascat:hasUnsteadyFlow kanawha:ElkMiddle.u02,
-        kanawha:ElkMiddle.u04,
-        kanawha:ElkMiddle.u05,
-        kanawha:ElkMiddle.u06 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:ElkMiddle.g01,
+        kanawha_models:ElkMiddle.g02 ;
+    rascat:hasPlan kanawha_models:ElkMiddle.p01,
+        kanawha_models:ElkMiddle.p03,
+        kanawha_models:ElkMiddle.p04,
+        kanawha_models:ElkMiddle.p06 ;
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u02,
+        kanawha_models:ElkMiddle.u04,
+        kanawha_models:ElkMiddle.u05,
+        kanawha_models:ElkMiddle.u06 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:G5.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "dami.george@wsp.com" ;
-            foaf:name "Dami George" ],
-        [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ] ;
+kanawha_models:G5.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Dami_George,
+        ffrd_people:Josh_Hill ;
     dcterms:description "2D rain-on-mesh BLE model of the 5th of nine Greenbrier River basins in south-central West Virginia." ;
     dcterms:title "G5" ;
-    rascat:hasGeometry kanawha:G5.g01,
-        kanawha:G5.g02,
-        kanawha:G5.g03 ;
-    rascat:hasPlan kanawha:G5.p01,
-        kanawha:G5.p04,
-        kanawha:G5.p05,
-        kanawha:G5.p06,
-        kanawha:G5.p11,
-        kanawha:G5.p12,
-        kanawha:G5.p13,
-        kanawha:G5.p14 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u01,
-        kanawha:G5.u05,
-        kanawha:G5.u06,
-        kanawha:G5.u07,
-        kanawha:G5.u08,
-        kanawha:G5.u09,
-        kanawha:G5.u10,
-        kanawha:G5.u11 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:G5.g01,
+        kanawha_models:G5.g02,
+        kanawha_models:G5.g03 ;
+    rascat:hasPlan kanawha_models:G5.p01,
+        kanawha_models:G5.p04,
+        kanawha_models:G5.p05,
+        kanawha_models:G5.p06,
+        kanawha_models:G5.p11,
+        kanawha_models:G5.p12,
+        kanawha_models:G5.p13,
+        kanawha_models:G5.p14 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u01,
+        kanawha_models:G5.u05,
+        kanawha_models:G5.u06,
+        kanawha_models:G5.u07,
+        kanawha_models:G5.u08,
+        kanawha_models:G5.u09,
+        kanawha_models:G5.u10,
+        kanawha_models:G5.u11 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:GSummersville_B.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "mmcbroom@mbakerintl.com" ;
-            foaf:name "Mark McBroom" ],
-        [ a foaf:Person ;
-            foaf:mbox "daniyal.siddiqui@mbakerintl.com" ;
-            foaf:name "Daniyal Siddiqui" ] ;
+kanawha_models:GSummersville_B.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Daniyal_Siddiqui,
+        ffrd_people:Mark_McBroom ;
     dcterms:description "2D rain-on-mesh BLE model of the Gauley River subbasin upstream of Summerville, West Virginia. INNOVATION PROJECT #2 - 2D RAS FFRD PILOT Technical Advisement to FY21 IRWA with USACE" ;
     dcterms:modified "2022-10-20T21:43:00"^^xsd:dateTime ;
     dcterms:title "GauleySummersville_BLE_FEMA" ;
-    rascat:hasGeometry kanawha:GSummersville_B.g01 ;
-    rascat:hasPlan kanawha:GSummersville_B.p01,
-        kanawha:GSummersville_B.p02,
-        kanawha:GSummersville_B.p11,
-        kanawha:GSummersville_B.p12 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_B.u01,
-        kanawha:GSummersville_B.u03,
-        kanawha:GSummersville_B.u05,
-        kanawha:GSummersville_B.u07 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
+    rascat:hasPlan kanawha_models:GSummersville_B.p01,
+        kanawha_models:GSummersville_B.p02,
+        kanawha_models:GSummersville_B.p11,
+        kanawha_models:GSummersville_B.p12 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u01,
+        kanawha_models:GSummersville_B.u03,
+        kanawha_models:GSummersville_B.u05,
+        kanawha_models:GSummersville_B.u07 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:GSummersville_C.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "daniyal.siddiqui@mbakerintl.com" ;
-            foaf:name "Daniyal Siddiqui" ],
-        [ a foaf:Person ;
-            foaf:mbox "mmcbroom@mbakerintl.com" ;
-            foaf:name "Mark McBroom" ] ;
+kanawha_models:GSummersville_C.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Daniyal_Siddiqui,
+        ffrd_people:Mark_McBroom ;
     dcterms:description "2D rain-on-mesh BLE model of the Gauley River subbasin upstream of Summerville, West Virginia. INNOVATION PROJECT #2 - 2D RAS FFRD PILOT Technical Advisement to FY21 IRWA with USACE" ;
     dcterms:modified "2022-10-25T20:07:00"^^xsd:dateTime ;
     dcterms:title "GauleySummersville_BLE-C_FEMA" ;
-    rascat:hasGeometry kanawha:GSummersville_C.g01 ;
-    rascat:hasPlan kanawha:GSummersville_C.p02,
-        kanawha:GSummersville_C.p03,
-        kanawha:GSummersville_C.p04,
-        kanawha:GSummersville_C.p05,
-        kanawha:GSummersville_C.p06,
-        kanawha:GSummersville_C.p07 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_C.u03,
-        kanawha:GSummersville_C.u04,
-        kanawha:GSummersville_C.u05,
-        kanawha:GSummersville_C.u06 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
+    rascat:hasPlan kanawha_models:GSummersville_C.p02,
+        kanawha_models:GSummersville_C.p03,
+        kanawha_models:GSummersville_C.p04,
+        kanawha_models:GSummersville_C.p05,
+        kanawha_models:GSummersville_C.p06,
+        kanawha_models:GSummersville_C.p07 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u03,
+        kanawha_models:GSummersville_C.u04,
+        kanawha_models:GSummersville_C.u05,
+        kanawha_models:GSummersville_C.u06 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:GauleyLower_BLE_FEM.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "mmcbroom@mbakerintl.com" ;
-            foaf:name "Mark McBroom" ],
-        [ a foaf:Person ;
-            foaf:mbox "John.Capobianco@mbakerintl.com" ;
-            foaf:name "John Capobianco" ] ;
+kanawha_models:GauleyLower_BLE_FEM.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:John_Capobianco,
+        ffrd_people:Mark_McBroom ;
     dcterms:description "" ;
     dcterms:title "GauleyLower_BLE-C_FEMA" ;
-    rascat:hasGeometry kanawha:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasPlan kanawha:GauleyLower_BLE_FEM.p01,
-        kanawha:GauleyLower_BLE_FEM.p02,
-        kanawha:GauleyLower_BLE_FEM.p03,
-        kanawha:GauleyLower_BLE_FEM.p06 ;
-    rascat:hasUnsteadyFlow kanawha:GauleyLower_BLE_FEM.u01,
-        kanawha:GauleyLower_BLE_FEM.u02,
-        kanawha:GauleyLower_BLE_FEM.u03,
-        kanawha:GauleyLower_BLE_FEM.u04 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
+    rascat:hasPlan kanawha_models:GauleyLower_BLE_FEM.p01,
+        kanawha_models:GauleyLower_BLE_FEM.p02,
+        kanawha_models:GauleyLower_BLE_FEM.p03,
+        kanawha_models:GauleyLower_BLE_FEM.p06 ;
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u01,
+        kanawha_models:GauleyLower_BLE_FEM.u02,
+        kanawha_models:GauleyLower_BLE_FEM.u03,
+        kanawha_models:GauleyLower_BLE_FEM.u04 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:Greenbrier_G7.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "dami.george@wsp.com" ;
-            foaf:name "Dami George" ],
-        [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ] ;
+kanawha_models:Greenbrier_G7.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Dami_George,
+        ffrd_people:Josh_Hill ;
     dcterms:description "2D rain-on-mesh BLE model of the 7th of nine Greenbrier River basins in south-central West Virginia." ;
     dcterms:title "Greenbrier_G7" ;
-    rascat:hasGeometry kanawha:Greenbrier_G7.g01,
-        kanawha:Greenbrier_G7.g02,
-        kanawha:Greenbrier_G7.g03 ;
-    rascat:hasPlan kanawha:Greenbrier_G7.p01,
-        kanawha:Greenbrier_G7.p03,
-        kanawha:Greenbrier_G7.p04,
-        kanawha:Greenbrier_G7.p05,
-        kanawha:Greenbrier_G7.p06,
-        kanawha:Greenbrier_G7.p07 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G7.u01,
-        kanawha:Greenbrier_G7.u03,
-        kanawha:Greenbrier_G7.u04,
-        kanawha:Greenbrier_G7.u05,
-        kanawha:Greenbrier_G7.u06,
-        kanawha:Greenbrier_G7.u07 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:Greenbrier_G7.g01,
+        kanawha_models:Greenbrier_G7.g02,
+        kanawha_models:Greenbrier_G7.g03 ;
+    rascat:hasPlan kanawha_models:Greenbrier_G7.p01,
+        kanawha_models:Greenbrier_G7.p03,
+        kanawha_models:Greenbrier_G7.p04,
+        kanawha_models:Greenbrier_G7.p05,
+        kanawha_models:Greenbrier_G7.p06,
+        kanawha_models:Greenbrier_G7.p07 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u01,
+        kanawha_models:Greenbrier_G7.u03,
+        kanawha_models:Greenbrier_G7.u04,
+        kanawha_models:Greenbrier_G7.u05,
+        kanawha_models:Greenbrier_G7.u06,
+        kanawha_models:Greenbrier_G7.u07 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:Greenbrier_G8.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "sirui.wen@wsp.com" ;
-            foaf:name "Sirui Wen" ],
-        [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ] ;
+kanawha_models:Greenbrier_G8.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Josh_Hill,
+        ffrd_people:Sirui_Wen ;
     dcterms:description "2D rain-on-mesh BLE model of the 8th of nine Greenbrier River basins in south-central West Virginia." ;
     dcterms:title "Greenbrier_G8" ;
-    rascat:hasGeometry kanawha:Greenbrier_G8.g01,
-        kanawha:Greenbrier_G8.g02,
-        kanawha:Greenbrier_G8.g03 ;
-    rascat:hasPlan kanawha:Greenbrier_G8.p01,
-        kanawha:Greenbrier_G8.p03,
-        kanawha:Greenbrier_G8.p04,
-        kanawha:Greenbrier_G8.p05,
-        kanawha:Greenbrier_G8.p06,
-        kanawha:Greenbrier_G8.p07 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G8.u01,
-        kanawha:Greenbrier_G8.u02,
-        kanawha:Greenbrier_G8.u03,
-        kanawha:Greenbrier_G8.u04,
-        kanawha:Greenbrier_G8.u05,
-        kanawha:Greenbrier_G8.u06,
-        kanawha:Greenbrier_G8.u07 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:Greenbrier_G8.g01,
+        kanawha_models:Greenbrier_G8.g02,
+        kanawha_models:Greenbrier_G8.g03 ;
+    rascat:hasPlan kanawha_models:Greenbrier_G8.p01,
+        kanawha_models:Greenbrier_G8.p03,
+        kanawha_models:Greenbrier_G8.p04,
+        kanawha_models:Greenbrier_G8.p05,
+        kanawha_models:Greenbrier_G8.p06,
+        kanawha_models:Greenbrier_G8.p07 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u01,
+        kanawha_models:Greenbrier_G8.u02,
+        kanawha_models:Greenbrier_G8.u03,
+        kanawha_models:Greenbrier_G8.u04,
+        kanawha_models:Greenbrier_G8.u05,
+        kanawha_models:Greenbrier_G8.u06,
+        kanawha_models:Greenbrier_G8.u07 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:Kanawha_G1.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ],
-        [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "julianna.villa@wsp.com" ;
-            foaf:name "Julianna Villa" ] ;
+kanawha_models:Kanawha_G1.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Josh_Hill,
+        ffrd_people:Julianna_Villa ;
     dcterms:description "2D rain-on-mesh BLE model of the first of nine Greenbrier River basins in south-central West Virginia." ;
     dcterms:modified "2022-11-14T18:59:00"^^xsd:dateTime ;
     dcterms:title "Kanawha_G1" ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g01,
-        kanawha:Kanawha_G1.g02,
-        kanawha:Kanawha_G1.g03 ;
-    rascat:hasPlan kanawha:Kanawha_G1.p01,
-        kanawha:Kanawha_G1.p02,
-        kanawha:Kanawha_G1.p03,
-        kanawha:Kanawha_G1.p04,
-        kanawha:Kanawha_G1.p05,
-        kanawha:Kanawha_G1.p06,
-        kanawha:Kanawha_G1.p07,
-        kanawha:Kanawha_G1.p08 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u01,
-        kanawha:Kanawha_G1.u02,
-        kanawha:Kanawha_G1.u03,
-        kanawha:Kanawha_G1.u04,
-        kanawha:Kanawha_G1.u05,
-        kanawha:Kanawha_G1.u06,
-        kanawha:Kanawha_G1.u07,
-        kanawha:Kanawha_G1.u08 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g01,
+        kanawha_models:Kanawha_G1.g02,
+        kanawha_models:Kanawha_G1.g03 ;
+    rascat:hasPlan kanawha_models:Kanawha_G1.p01,
+        kanawha_models:Kanawha_G1.p02,
+        kanawha_models:Kanawha_G1.p03,
+        kanawha_models:Kanawha_G1.p04,
+        kanawha_models:Kanawha_G1.p05,
+        kanawha_models:Kanawha_G1.p06,
+        kanawha_models:Kanawha_G1.p07,
+        kanawha_models:Kanawha_G1.p08 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u01,
+        kanawha_models:Kanawha_G1.u02,
+        kanawha_models:Kanawha_G1.u03,
+        kanawha_models:Kanawha_G1.u04,
+        kanawha_models:Kanawha_G1.u05,
+        kanawha_models:Kanawha_G1.u06,
+        kanawha_models:Kanawha_G1.u07,
+        kanawha_models:Kanawha_G1.u08 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:Kanawha_G2.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "julianna.villa@wsp.com" ;
-            foaf:name "Julianna Villa" ],
-        [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ] ;
+kanawha_models:Kanawha_G2.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Josh_Hill,
+        ffrd_people:Julianna_Villa ;
     dcterms:description "2D rain-on-mesh BLE model of the second of nine Greenbrier River basins in south-central West Virginia. " ;
     dcterms:modified "2022-11-14T18:59:00"^^xsd:dateTime ;
     dcterms:title "Kanawha_G2" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g01,
-        kanawha:Kanawha_G2.g02,
-        kanawha:Kanawha_G2.g03 ;
-    rascat:hasPlan kanawha:Kanawha_G2.p01,
-        kanawha:Kanawha_G2.p02,
-        kanawha:Kanawha_G2.p03,
-        kanawha:Kanawha_G2.p04,
-        kanawha:Kanawha_G2.p05,
-        kanawha:Kanawha_G2.p06,
-        kanawha:Kanawha_G2.p07,
-        kanawha:Kanawha_G2.p08 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u01,
-        kanawha:Kanawha_G2.u02,
-        kanawha:Kanawha_G2.u03,
-        kanawha:Kanawha_G2.u04,
-        kanawha:Kanawha_G2.u05,
-        kanawha:Kanawha_G2.u06,
-        kanawha:Kanawha_G2.u07,
-        kanawha:Kanawha_G2.u08 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g01,
+        kanawha_models:Kanawha_G2.g02,
+        kanawha_models:Kanawha_G2.g03 ;
+    rascat:hasPlan kanawha_models:Kanawha_G2.p01,
+        kanawha_models:Kanawha_G2.p02,
+        kanawha_models:Kanawha_G2.p03,
+        kanawha_models:Kanawha_G2.p04,
+        kanawha_models:Kanawha_G2.p05,
+        kanawha_models:Kanawha_G2.p06,
+        kanawha_models:Kanawha_G2.p07,
+        kanawha_models:Kanawha_G2.p08 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u01,
+        kanawha_models:Kanawha_G2.u02,
+        kanawha_models:Kanawha_G2.u03,
+        kanawha_models:Kanawha_G2.u04,
+        kanawha_models:Kanawha_G2.u05,
+        kanawha_models:Kanawha_G2.u06,
+        kanawha_models:Kanawha_G2.u07,
+        kanawha_models:Kanawha_G2.u08 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:New-LittleRiver.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "reuben.cozmyer@aecom.com" ;
-            foaf:name "Reuben Cozmyer" ],
-        [ a foaf:Person ;
-            foaf:mbox "ryan.pohl@aecom.com" ;
-            foaf:name "Ryan Pohl" ] ;
+kanawha_models:New-LittleRiver.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Reuben_Cozmyer,
+        ffrd_people:Ryan_Pohl ;
     dcterms:description "" ;
     dcterms:modified "2023-01-25T23:59:00"^^xsd:dateTime ;
     dcterms:title "New-Little River" ;
-    rascat:hasGeometry kanawha:New-LittleRiver.g01 ;
-    rascat:hasPlan kanawha:New-LittleRiver.p05,
-        kanawha:New-LittleRiver.p06,
-        kanawha:New-LittleRiver.p07,
-        kanawha:New-LittleRiver.p17,
-        kanawha:New-LittleRiver.p19 ;
-    rascat:hasUnsteadyFlow kanawha:New-LittleRiver.u05,
-        kanawha:New-LittleRiver.u07,
-        kanawha:New-LittleRiver.u08,
-        kanawha:New-LittleRiver.u09,
-        kanawha:New-LittleRiver.u10 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
+    rascat:hasPlan kanawha_models:New-LittleRiver.p05,
+        kanawha_models:New-LittleRiver.p06,
+        kanawha_models:New-LittleRiver.p07,
+        kanawha_models:New-LittleRiver.p17,
+        kanawha_models:New-LittleRiver.p19 ;
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u05,
+        kanawha_models:New-LittleRiver.u07,
+        kanawha_models:New-LittleRiver.u08,
+        kanawha_models:New-LittleRiver.u09,
+        kanawha_models:New-LittleRiver.u10 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.0" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:UpperKanawha.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "Matt.Lewis@freese.com" ;
-            foaf:name "Matt Lewis" ],
-        [ a foaf:Person ;
-            foaf:mbox "Andrew.Swynenberg@freese.com" ;
-            foaf:name "Andrew Swynenberg" ],
-        [ a foaf:Person ;
-            foaf:mbox "Dawit.Zeweldi@freese.com" ;
-            foaf:name "Dawit Zeweldi" ] ;
+kanawha_models:UpperKanawha.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Andrew_Swynenberg,
+        ffrd_people:Dawit_Zeweldi,
+        ffrd_people:Matt_Lewis ;
     dcterms:description """Watershed: Upper Kanawha River
 Vertical Datum: NAVD 88
 Units: Feet
@@ -440,167 +369,143 @@ Modeler: Freese and Nichols, Inc.
 Model Version: HEC-RAS v6.3
 Date: September 30, 2022""" ;
     dcterms:title "Upper Kanawha" ;
-    rascat:hasGeometry kanawha:UpperKanawha.g01 ;
-    rascat:hasPlan kanawha:UpperKanawha.p01,
-        kanawha:UpperKanawha.p02,
-        kanawha:UpperKanawha.p03,
-        kanawha:UpperKanawha.p04,
-        kanawha:UpperKanawha.p05,
-        kanawha:UpperKanawha.p06 ;
-    rascat:hasUnsteadyFlow kanawha:UpperKanawha.u01,
-        kanawha:UpperKanawha.u02,
-        kanawha:UpperKanawha.u07,
-        kanawha:UpperKanawha.u08,
-        kanawha:UpperKanawha.u09,
-        kanawha:UpperKanawha.u11 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
+    rascat:hasPlan kanawha_models:UpperKanawha.p01,
+        kanawha_models:UpperKanawha.p02,
+        kanawha_models:UpperKanawha.p03,
+        kanawha_models:UpperKanawha.p04,
+        kanawha_models:UpperKanawha.p05,
+        kanawha_models:UpperKanawha.p06 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u01,
+        kanawha_models:UpperKanawha.u02,
+        kanawha_models:UpperKanawha.u07,
+        kanawha_models:UpperKanawha.u08,
+        kanawha_models:UpperKanawha.u09,
+        kanawha_models:UpperKanawha.u11 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:UpperNew_Lower.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "reuben.cozmyer@aecom.com" ;
-            foaf:name "Reuben Cozmyer" ],
-        [ a foaf:Person ;
-            foaf:mbox "elizabeth.vandekrol@aecom.com" ;
-            foaf:name "Elizabeth Vande Krol" ] ;
+kanawha_models:UpperNew_Lower.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Elizabeth_Vande_Krol,
+        ffrd_people:Reuben_Cozmyer ;
     dcterms:description "2D rain-on-mesh BLE model of the New River Basin in Wythe and Carroll counties, West Virginia." ;
     dcterms:modified "2023-01-01T13:15:00"^^xsd:dateTime ;
     dcterms:title "UpperNew_Lower" ;
-    rascat:hasGeometry kanawha:UpperNew_Lower.g03 ;
-    rascat:hasPlan kanawha:UpperNew_Lower.p01,
-        kanawha:UpperNew_Lower.p02,
-        kanawha:UpperNew_Lower.p03,
-        kanawha:UpperNew_Lower.p04,
-        kanawha:UpperNew_Lower.p07 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Lower.u01,
-        kanawha:UpperNew_Lower.u02,
-        kanawha:UpperNew_Lower.u03,
-        kanawha:UpperNew_Lower.u04,
-        kanawha:UpperNew_Lower.u05 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
+    rascat:hasPlan kanawha_models:UpperNew_Lower.p01,
+        kanawha_models:UpperNew_Lower.p02,
+        kanawha_models:UpperNew_Lower.p03,
+        kanawha_models:UpperNew_Lower.p04,
+        kanawha_models:UpperNew_Lower.p07 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u01,
+        kanawha_models:UpperNew_Lower.u02,
+        kanawha_models:UpperNew_Lower.u03,
+        kanawha_models:UpperNew_Lower.u04,
+        kanawha_models:UpperNew_Lower.u05 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:UpperNew_Upper.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "michelle.terry@aecom.com" ;
-            foaf:name "Michelle Terry" ] ;
+kanawha_models:UpperNew_Upper.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Michelle_Terry ;
     dcterms:description "" ;
     dcterms:modified "2022-12-08T13:17:00"^^xsd:dateTime ;
     dcterms:title "UpperNew_Upper" ;
-    rascat:hasGeometry kanawha:UpperNew_Upper.g01 ;
-    rascat:hasPlan kanawha:UpperNew_Upper.p01,
-        kanawha:UpperNew_Upper.p02,
-        kanawha:UpperNew_Upper.p03,
-        kanawha:UpperNew_Upper.p04 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Upper.u01,
-        kanawha:UpperNew_Upper.u02,
-        kanawha:UpperNew_Upper.u03,
-        kanawha:UpperNew_Upper.u04,
-        kanawha:UpperNew_Upper.u05 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
+    rascat:hasPlan kanawha_models:UpperNew_Upper.p01,
+        kanawha_models:UpperNew_Upper.p02,
+        kanawha_models:UpperNew_Upper.p03,
+        kanawha_models:UpperNew_Upper.p04 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u01,
+        kanawha_models:UpperNew_Upper.u02,
+        kanawha_models:UpperNew_Upper.u03,
+        kanawha_models:UpperNew_Upper.u04,
+        kanawha_models:UpperNew_Upper.u05 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:WatershedG3.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ],
-        [ a foaf:Person ;
-            foaf:mbox "jonathan.bartlotti@wsp.com" ;
-            foaf:name "Jon Bartlotti" ] ;
+kanawha_models:WatershedG3.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Jon_Bartlotti,
+        ffrd_people:Josh_Hill ;
     dcterms:description "2D rain-on-mesh BLE model of the third of nine Greenbrier River basins in south-central West Virginia." ;
     dcterms:modified "2022-11-14T18:30:00"^^xsd:dateTime ;
     dcterms:title "Watershed G3" ;
-    rascat:hasGeometry kanawha:WatershedG3.g01,
-        kanawha:WatershedG3.g02,
-        kanawha:WatershedG3.g03 ;
-    rascat:hasPlan kanawha:WatershedG3.p01,
-        kanawha:WatershedG3.p02,
-        kanawha:WatershedG3.p03,
-        kanawha:WatershedG3.p04,
-        kanawha:WatershedG3.p05,
-        kanawha:WatershedG3.p06,
-        kanawha:WatershedG3.p07,
-        kanawha:WatershedG3.p08 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u01,
-        kanawha:WatershedG3.u02,
-        kanawha:WatershedG3.u03,
-        kanawha:WatershedG3.u04,
-        kanawha:WatershedG3.u05 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:WatershedG3.g01,
+        kanawha_models:WatershedG3.g02,
+        kanawha_models:WatershedG3.g03 ;
+    rascat:hasPlan kanawha_models:WatershedG3.p01,
+        kanawha_models:WatershedG3.p02,
+        kanawha_models:WatershedG3.p03,
+        kanawha_models:WatershedG3.p04,
+        kanawha_models:WatershedG3.p05,
+        kanawha_models:WatershedG3.p06,
+        kanawha_models:WatershedG3.p07,
+        kanawha_models:WatershedG3.p08 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u01,
+        kanawha_models:WatershedG3.u02,
+        kanawha_models:WatershedG3.u03,
+        kanawha_models:WatershedG3.u04,
+        kanawha_models:WatershedG3.u05 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:WatershedG4.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "jonathan.bartlotti@wsp.com" ;
-            foaf:name "Jonathan Bartlotti" ],
-        [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ] ;
+kanawha_models:WatershedG4.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Jonathan_Bartlotti,
+        ffrd_people:Josh_Hill ;
     dcterms:description "2D rain-on-mesh BLE model of the fourth of nine Greenbrier River basins in south-central West Virginia." ;
     dcterms:title "Watershed G4" ;
-    rascat:hasGeometry kanawha:WatershedG4.g01,
-        kanawha:WatershedG4.g02,
-        kanawha:WatershedG4.g03 ;
-    rascat:hasPlan kanawha:WatershedG4.p01,
-        kanawha:WatershedG4.p02,
-        kanawha:WatershedG4.p03,
-        kanawha:WatershedG4.p04,
-        kanawha:WatershedG4.p05,
-        kanawha:WatershedG4.p06,
-        kanawha:WatershedG4.p07,
-        kanawha:WatershedG4.p08 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u01,
-        kanawha:WatershedG4.u02,
-        kanawha:WatershedG4.u03,
-        kanawha:WatershedG4.u04 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:WatershedG4.g01,
+        kanawha_models:WatershedG4.g02,
+        kanawha_models:WatershedG4.g03 ;
+    rascat:hasPlan kanawha_models:WatershedG4.p01,
+        kanawha_models:WatershedG4.p02,
+        kanawha_models:WatershedG4.p03,
+        kanawha_models:WatershedG4.p04,
+        kanawha_models:WatershedG4.p05,
+        kanawha_models:WatershedG4.p06,
+        kanawha_models:WatershedG4.p07,
+        kanawha_models:WatershedG4.p08 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u01,
+        kanawha_models:WatershedG4.u02,
+        kanawha_models:WatershedG4.u03,
+        kanawha_models:WatershedG4.u04 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha:WatershedG9.prj a rascat:RasModel ;
-    dcterms:creator [ a foaf:Person ;
-            foaf:mbox "josh.hill@wsp.com" ;
-            foaf:name "Josh Hill" ],
-        [ a foaf:Person ;
-            foaf:mbox "ben.rufenacht@wsp.com" ;
-            foaf:name "Ben Rufenacht" ],
-        [ a foaf:Person ;
-            foaf:mbox "jonathan.bartlotti@wsp.com" ;
-            foaf:name "Jonathan Bartlotti" ] ;
+kanawha_models:WatershedG9.prj a rascat:RasModel ;
+    dcterms:creator ffrd_people:Ben_Rufenacht,
+        ffrd_people:Jonathan_Bartlotti,
+        ffrd_people:Josh_Hill ;
     dcterms:description "2D rain-on-mesh BLE model of the ninth of nine Greenbrier River basins in south-central West Virginia." ;
     dcterms:modified "2022-11-14T19:26:00"^^xsd:dateTime ;
     dcterms:title "WatershedG9" ;
-    rascat:hasGeometry kanawha:WatershedG9.g01,
-        kanawha:WatershedG9.g02,
-        kanawha:WatershedG9.g03 ;
-    rascat:hasPlan kanawha:WatershedG9.p01,
-        kanawha:WatershedG9.p02,
-        kanawha:WatershedG9.p03,
-        kanawha:WatershedG9.p04,
-        kanawha:WatershedG9.p05,
-        kanawha:WatershedG9.p06,
-        kanawha:WatershedG9.p07,
-        kanawha:WatershedG9.p08 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u01,
-        kanawha:WatershedG9.u02,
-        kanawha:WatershedG9.u03,
-        kanawha:WatershedG9.u04 ;
-    rascat:projection kanawha:mmc_albers_ft.prj ;
+    rascat:hasGeometry kanawha_models:WatershedG9.g01,
+        kanawha_models:WatershedG9.g02,
+        kanawha_models:WatershedG9.g03 ;
+    rascat:hasPlan kanawha_models:WatershedG9.p01,
+        kanawha_models:WatershedG9.p02,
+        kanawha_models:WatershedG9.p03,
+        kanawha_models:WatershedG9.p04,
+        kanawha_models:WatershedG9.p05,
+        kanawha_models:WatershedG9.p06,
+        kanawha_models:WatershedG9.p07,
+        kanawha_models:WatershedG9.p08 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01,
+        kanawha_models:WatershedG9.u02,
+        kanawha_models:WatershedG9.u03,
+        kanawha_models:WatershedG9.u04 ;
+    rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
@@ -610,47 +515,48 @@ kanawha:WatershedG9.prj a rascat:RasModel ;
     dcterms:publisher "USACE" ;
     dcterms:title "Summersville Lake" .
 
-kanawha:BasinG6.p01 a rascat:RasPlan ;
+kanawha_models:BasinG6.p01 a rascat:RasPlan ;
     dcterms:description "Plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
-    rascat:hasGeometry kanawha:BasinG6.g01 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u01 .
+    rascat:hasGeometry kanawha_models:BasinG6.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u01 .
 
-kanawha:BasinG6.p02 a rascat:RasPlan ;
+kanawha_models:BasinG6.p02 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:BasinG6.g01 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u04 .
+    rascat:hasGeometry kanawha_models:BasinG6.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u04 .
 
-kanawha:BasinG6.p03 a rascat:RasPlan ;
+kanawha_models:BasinG6.p03 a rascat:RasPlan ;
     dcterms:description "Plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
-    rascat:hasGeometry kanawha:BasinG6.g01 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u01 .
+    rascat:hasGeometry kanawha_models:BasinG6.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u01 .
 
-kanawha:BasinG6.p04 a rascat:RasPlan ;
+kanawha_models:BasinG6.p04 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:BasinG6.g02 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u02 .
+    rascat:hasGeometry kanawha_models:BasinG6.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u02 .
 
-kanawha:BasinG6.p05 a rascat:RasPlan ;
+kanawha_models:BasinG6.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasGeometry kanawha:BasinG6.g02 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u03 .
+    rascat:hasGeometry kanawha_models:BasinG6.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u03 .
 
-kanawha:BasinG6.p06 a rascat:RasPlan ;
+kanawha_models:BasinG6.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasGeometry kanawha:BasinG6.g03 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u07 .
+    rascat:hasGeometry kanawha_models:BasinG6.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u07 .
 
-kanawha:BasinG6.p07 a rascat:RasPlan ;
+kanawha_models:BasinG6.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasGeometry kanawha:BasinG6.g01 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u05 .
+    rascat:hasGeometry kanawha_models:BasinG6.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u05 .
 
-kanawha:BasinG6.p08 a rascat:RasPlan ;
+kanawha_models:BasinG6.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2023-03-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03182888 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 6.4704e-01 ;
@@ -658,13 +564,14 @@ kanawha:BasinG6.p08 a rascat:RasPlan ;
             rascat:r2 9.0879e-01 ;
             rascat:rsr 5.9411e-01 ;
             rascat:startDateTime "2007-10-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:BasinG6.g02 ;
-    rascat:hasUnsteadyFlow kanawha:BasinG6.u06 .
+    rascat:hasGeometry kanawha_models:BasinG6.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u06 .
 
-kanawha:BluestoneLocal.p01 a rascat:RasPlan ;
+kanawha_models:BluestoneLocal.p01 a rascat:RasPlan ;
     dcterms:title "JAN1995" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03179800 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 9.43e-01 ;
@@ -672,13 +579,14 @@ kanawha:BluestoneLocal.p01 a rascat:RasPlan ;
             rascat:r2 9.46e-01 ;
             rascat:rsr 2.53e-01 ;
             rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:BluestoneLocal.g01 ;
-    rascat:hasUnsteadyFlow kanawha:BluestoneLocal.u01 .
+    rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u01 .
 
-kanawha:BluestoneLocal.p02 a rascat:RasPlan ;
+kanawha_models:BluestoneLocal.p02 a rascat:RasPlan ;
     dcterms:title "JAN1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-01-30T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03179800 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 8.8e-01 ;
@@ -686,13 +594,14 @@ kanawha:BluestoneLocal.p02 a rascat:RasPlan ;
             rascat:r2 8.8e-01 ;
             rascat:rsr 3.6e-01 ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:BluestoneLocal.g01 ;
-    rascat:hasUnsteadyFlow kanawha:BluestoneLocal.u02 .
+    rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u02 .
 
-kanawha:BluestoneLocal.p03 a rascat:RasPlan ;
+kanawha_models:BluestoneLocal.p03 a rascat:RasPlan ;
     dcterms:title "NOV2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-27T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03179800 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 9.5e-01 ;
@@ -700,13 +609,14 @@ kanawha:BluestoneLocal.p03 a rascat:RasPlan ;
             rascat:r2 9.5e-01 ;
             rascat:rsr 2.3e-01 ;
             rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:BluestoneLocal.g01 ;
-    rascat:hasUnsteadyFlow kanawha:BluestoneLocal.u03 .
+    rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u03 .
 
-kanawha:BluestoneLocal.p04 a rascat:RasPlan ;
+kanawha_models:BluestoneLocal.p04 a rascat:RasPlan ;
     dcterms:title "JUN2016" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03177120 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 2.9e-01 ;
@@ -716,6 +626,7 @@ kanawha:BluestoneLocal.p04 a rascat:RasPlan ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03179800 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 4e-02 ;
@@ -723,10 +634,10 @@ kanawha:BluestoneLocal.p04 a rascat:RasPlan ;
             rascat:r2 1e-02 ;
             rascat:rsr 1.11e+00 ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:BluestoneLocal.g01 ;
-    rascat:hasUnsteadyFlow kanawha:BluestoneLocal.u04 .
+    rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u04 .
 
-kanawha:Bluestone_Upper.p15 a rascat:RasPlan ;
+kanawha_models:Bluestone_Upper.p15 a rascat:RasPlan ;
     dcterms:description """Jan 5-29, 1995 (UTC) using excess precip from Corps HMS model plus baseflow
 400ft cell sizes, 100ft stream refinement, 50ft community
 Some  Breaklines and Terrain mods
@@ -734,24 +645,26 @@ Some  Breaklines and Terrain mods
     dcterms:title "Jan1995" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03177710 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 5.6e-01 ;
-            rascat:r2 6.2e-01 ;
-            rascat:rsr 6.6e-01 ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03179000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 8.4e-01 ;
             rascat:r2 8.8e-01 ;
             rascat:rsr 3.9e-01 ;
+            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03177710 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 5.6e-01 ;
+            rascat:r2 6.2e-01 ;
+            rascat:rsr 6.6e-01 ;
             rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Bluestone_Upper.g07 ;
-    rascat:hasUnsteadyFlow kanawha:Bluestone_Upper.u07 .
+    rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u07 .
 
-kanawha:Bluestone_Upper.p16 a rascat:RasPlan ;
+kanawha_models:Bluestone_Upper.p16 a rascat:RasPlan ;
     dcterms:description """14 Jan - 6 Feb 1996 (UTC) excess precip from HMS plus baseflow
 400x400 ft cell sizes, 100 ft stream refinement, 50 ft towns
 Somebreaklines and terrain mods
@@ -759,26 +672,28 @@ Somebreaklines and terrain mods
     dcterms:title "Jan1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03177710 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.9e-01 ;
-            rascat:pbias 1.316e+01 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 3.3e-01 ;
-            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03179000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 8.2e-01 ;
             rascat:pbias 1.383e+01 ;
             rascat:r2 8.8e-01 ;
             rascat:rsr 4.2e-01 ;
+            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
+            rascat:fromStreamgage usgs_gages:03177710 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 8.9e-01 ;
+            rascat:pbias 1.316e+01 ;
+            rascat:r2 9.1e-01 ;
+            rascat:rsr 3.3e-01 ;
             rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Bluestone_Upper.g07 ;
-    rascat:hasUnsteadyFlow kanawha:Bluestone_Upper.u08 .
+    rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u08 .
 
-kanawha:Bluestone_Upper.p17 a rascat:RasPlan ;
+kanawha_models:Bluestone_Upper.p17 a rascat:RasPlan ;
     dcterms:description """Jun 20 - Jul 3, 2016 (UTC) using Excess Precipitation from Corps HMS model plus baseflow
 400 ft cell sizes
 100 ft stream refinement regions, 50 ft ref reg in towns
@@ -786,26 +701,28 @@ Some Breaklines and terrain mods""" ;
     dcterms:title "Jun2016" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03177710 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2e-01 ;
-            rascat:pbias 1.484e+01 ;
-            rascat:r2 1e-02 ;
-            rascat:rsr 1.09e+00 ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03179000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 3e-02 ;
             rascat:pbias 3.429e+01 ;
             rascat:r2 2.8e-01 ;
             rascat:rsr 9.9e-01 ;
+            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03177710 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse -2e-01 ;
+            rascat:pbias 1.484e+01 ;
+            rascat:r2 1e-02 ;
+            rascat:rsr 1.09e+00 ;
             rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Bluestone_Upper.g07 ;
-    rascat:hasUnsteadyFlow kanawha:Bluestone_Upper.u09 .
+    rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u09 .
 
-kanawha:Bluestone_Upper.p18 a rascat:RasPlan ;
+kanawha_models:Bluestone_Upper.p18 a rascat:RasPlan ;
     dcterms:description """Nov 6-24, 2003 (UTC) using Excess Precip from calibrated HEC-HMS model from Corps (2km cells) and Baseflow
 400x400 ft cell sizes
 100ft stream refinement , 50ft ref  in towns
@@ -813,28 +730,21 @@ Some breaklines and culvert terrain mods""" ;
     dcterms:title "Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03179000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 9.3e-01 ;
             rascat:r2 9.4e-01 ;
             rascat:rsr 2.7e-01 ;
             rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Bluestone_Upper.g07 ;
-    rascat:hasUnsteadyFlow kanawha:Bluestone_Upper.u06 .
+    rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u06 .
 
-kanawha:CoalRiver.p01 a rascat:RasPlan ;
+kanawha_models:CoalRiver.p01 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03198500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.5e-01 ;
-            rascat:pbias 1.206e+01 ;
-            rascat:r2 8.6e-01 ;
-            rascat:rsr 3.9e-01 ;
-            rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03198350 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 8.9e-01 ;
@@ -844,43 +754,57 @@ kanawha:CoalRiver.p01 a rascat:RasPlan ;
             rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03200500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 8.7e-01 ;
             rascat:pbias 1.417e+01 ;
             rascat:r2 8.9e-01 ;
             rascat:rsr 3.6e-01 ;
+            rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03198500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 8.5e-01 ;
+            rascat:pbias 1.206e+01 ;
+            rascat:r2 8.6e-01 ;
+            rascat:rsr 3.9e-01 ;
             rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:CoalRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:CoalRiver.u01 .
+    rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u01 .
 
-kanawha:CoalRiver.p02 a rascat:RasPlan ;
+kanawha_models:CoalRiver.p02 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03200500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 2.5e-01 ;
-            rascat:pbias 2.036e+01 ;
-            rascat:r2 3.2e-01 ;
-            rascat:rsr 8.4e-01 ;
-            rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03198500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 4e-02 ;
             rascat:pbias 3.598e+01 ;
             rascat:r2 2.3e-01 ;
             rascat:rsr 9.5e-01 ;
+            rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03200500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 2.5e-01 ;
+            rascat:pbias 2.036e+01 ;
+            rascat:r2 3.2e-01 ;
+            rascat:rsr 8.4e-01 ;
             rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:CoalRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:CoalRiver.u02 .
+    rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u02 .
 
-kanawha:CoalRiver.p03 a rascat:RasPlan ;
+kanawha_models:CoalRiver.p03 a rascat:RasPlan ;
     dcterms:title "Jan1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03200500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 7.2e-01 ;
@@ -890,6 +814,7 @@ kanawha:CoalRiver.p03 a rascat:RasPlan ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03198500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse -1.97e+00 ;
@@ -897,13 +822,24 @@ kanawha:CoalRiver.p03 a rascat:RasPlan ;
             rascat:r2 8e-02 ;
             rascat:rsr 1.67e+00 ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:CoalRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:CoalRiver.u03 .
+    rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u03 .
 
-kanawha:CoalRiver.p04 a rascat:RasPlan ;
+kanawha_models:CoalRiver.p04 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03200500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 7e-02 ;
+            rascat:pbias 3.821e+01 ;
+            rascat:r2 2.7e-01 ;
+            rascat:rsr 9.6e-01 ;
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03198350 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 5.7e-01 ;
@@ -913,39 +849,23 @@ kanawha:CoalRiver.p04 a rascat:RasPlan ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03198500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 3.6e-01 ;
             rascat:pbias 3.169e+01 ;
             rascat:r2 5e-01 ;
             rascat:rsr 8e-01 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03200500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7e-02 ;
-            rascat:pbias 3.821e+01 ;
-            rascat:r2 2.7e-01 ;
-            rascat:rsr 9.6e-01 ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:CoalRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:CoalRiver.u04 .
+    rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u04 .
 
-kanawha:ElkMiddle.p01 a rascat:RasPlan ;
+kanawha_models:ElkMiddle.p01 a rascat:RasPlan ;
     dcterms:description "November 2003.Calibrated to Queen Shoals Gage" ;
     dcterms:title "Unsteady_Mixed_Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.0487e-01 ;
-            rascat:pbias 1.3164e+01 ;
-            rascat:r2 9.2731e-01 ;
-            rascat:rsr 3.0843e-01 ;
-            rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03197000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 7.3831e-01 ;
@@ -955,38 +875,42 @@ kanawha:ElkMiddle.p01 a rascat:RasPlan ;
             rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03196800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.6802e-01 ;
-            rascat:pbias -1.3772e-01 ;
-            rascat:r2 9.3277e-01 ;
-            rascat:rsr 3.6328e-01 ;
-            rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03196600 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 3.1117e-01 ;
             rascat:pbias -1.6572e-01 ;
             rascat:r2 7.701e-01 ;
             rascat:rsr 8.2996e-01 ;
+            rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03197000 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 9.0487e-01 ;
+            rascat:pbias 1.3164e+01 ;
+            rascat:r2 9.2731e-01 ;
+            rascat:rsr 3.0843e-01 ;
+            rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03196800 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 8.6802e-01 ;
+            rascat:pbias -1.3772e-01 ;
+            rascat:r2 9.3277e-01 ;
+            rascat:rsr 3.6328e-01 ;
             rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:ElkMiddle.g01 ;
-    rascat:hasUnsteadyFlow kanawha:ElkMiddle.u02 .
+    rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u02 .
 
-kanawha:ElkMiddle.p03 a rascat:RasPlan ;
+kanawha_models:ElkMiddle.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jan1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03196600 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 3.7745e-01 ;
-            rascat:pbias 1.821e-01 ;
-            rascat:r2 6.5615e-01 ;
-            rascat:rsr 7.8902e-01 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03196800 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 2.812e-01 ;
@@ -996,6 +920,17 @@ kanawha:ElkMiddle.p03 a rascat:RasPlan ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
+            rascat:fromStreamgage usgs_gages:03196600 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 3.7745e-01 ;
+            rascat:pbias 1.821e-01 ;
+            rascat:r2 6.5615e-01 ;
+            rascat:rsr 7.8902e-01 ;
+            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03197000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -1.1679e+00 ;
@@ -1003,13 +938,14 @@ kanawha:ElkMiddle.p03 a rascat:RasPlan ;
             rascat:r2 6.1415e-01 ;
             rascat:rsr 1.4724e+00 ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:ElkMiddle.g02 ;
-    rascat:hasUnsteadyFlow kanawha:ElkMiddle.u05 .
+    rascat:hasGeometry kanawha_models:ElkMiddle.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u05 .
 
-kanawha:ElkMiddle.p04 a rascat:RasPlan ;
+kanawha_models:ElkMiddle.p04 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jun2016" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03197000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 9.3616e-01 ;
@@ -1019,33 +955,7 @@ kanawha:ElkMiddle.p04 a rascat:RasPlan ;
             rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03196500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 2.9614e-01 ;
-            rascat:pbias -6.8283e-02 ;
-            rascat:r2 5.6463e-01 ;
-            rascat:rsr 8.3896e-01 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03196800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 6.0684e-01 ;
-            rascat:pbias -3.9992e-01 ;
-            rascat:r2 8.5544e-01 ;
-            rascat:rsr 6.2702e-01 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03196600 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2.0927e-01 ;
-            rascat:pbias -2.8261e-01 ;
-            rascat:r2 7.4283e-01 ;
-            rascat:rsr 1.0997e+00 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03197000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 7.7057e-01 ;
@@ -1055,6 +965,37 @@ kanawha:ElkMiddle.p04 a rascat:RasPlan ;
             rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03196600 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse -2.0927e-01 ;
+            rascat:pbias -2.8261e-01 ;
+            rascat:r2 7.4283e-01 ;
+            rascat:rsr 1.0997e+00 ;
+            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03196800 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 6.0684e-01 ;
+            rascat:pbias -3.9992e-01 ;
+            rascat:r2 8.5544e-01 ;
+            rascat:rsr 6.2702e-01 ;
+            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03196500 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 2.9614e-01 ;
+            rascat:pbias -6.8283e-02 ;
+            rascat:r2 5.6463e-01 ;
+            rascat:rsr 8.3896e-01 ;
+            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03196800 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 6.1359e-01 ;
@@ -1062,22 +1003,24 @@ kanawha:ElkMiddle.p04 a rascat:RasPlan ;
             rascat:r2 9.1515e-01 ;
             rascat:rsr 6.2162e-01 ;
             rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:ElkMiddle.g01 ;
-    rascat:hasUnsteadyFlow kanawha:ElkMiddle.u06 .
+    rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u06 .
 
-kanawha:ElkMiddle.p06 a rascat:RasPlan ;
+kanawha_models:ElkMiddle.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jan1995" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03196600 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse -1.3776e+00 ;
-            rascat:pbias 2.1848e-01 ;
-            rascat:r2 6.5966e-01 ;
-            rascat:rsr 1.5419e+00 ;
+            rascat:nse -8.3698e-01 ;
+            rascat:pbias -1.1895e-01 ;
+            rascat:r2 6.511e-01 ;
+            rascat:rsr 1.3554e+00 ;
             rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03197000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 4.3444e-01 ;
@@ -1087,74 +1030,77 @@ kanawha:ElkMiddle.p06 a rascat:RasPlan ;
             rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03197000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse -1.3776e+00 ;
+            rascat:pbias 2.1848e-01 ;
+            rascat:r2 6.5966e-01 ;
+            rascat:rsr 1.5419e+00 ;
+            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03196800 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -1.504e-01 ;
             rascat:pbias -2.2115e-01 ;
             rascat:r2 6.714e-01 ;
             rascat:rsr 1.0726e+00 ;
-            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03196600 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -8.3698e-01 ;
-            rascat:pbias -1.1895e-01 ;
-            rascat:r2 6.511e-01 ;
-            rascat:rsr 1.3554e+00 ;
             rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:ElkMiddle.g01 ;
-    rascat:hasUnsteadyFlow kanawha:ElkMiddle.u04 .
+    rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u04 .
 
-kanawha:G5.p01 a rascat:RasPlan ;
+kanawha_models:G5.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:G5.g02 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u01 .
+    rascat:hasGeometry kanawha_models:G5.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u01 .
 
-kanawha:G5.p04 a rascat:RasPlan ;
+kanawha_models:G5.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
-    rascat:hasGeometry kanawha:G5.g01 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u01 .
+    rascat:hasGeometry kanawha_models:G5.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u01 .
 
-kanawha:G5.p05 a rascat:RasPlan ;
+kanawha_models:G5.p05 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:G5.g01 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u07 .
+    rascat:hasGeometry kanawha_models:G5.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u07 .
 
-kanawha:G5.p06 a rascat:RasPlan ;
+kanawha_models:G5.p06 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
-    rascat:hasGeometry kanawha:G5.g01 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u09 .
+    rascat:hasGeometry kanawha_models:G5.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u09 .
 
-kanawha:G5.p11 a rascat:RasPlan ;
+kanawha_models:G5.p11 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasGeometry kanawha:G5.g02 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u06 .
+    rascat:hasGeometry kanawha_models:G5.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u06 .
 
-kanawha:G5.p12 a rascat:RasPlan ;
+kanawha_models:G5.p12 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasGeometry kanawha:G5.g03 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u11 .
+    rascat:hasGeometry kanawha_models:G5.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u11 .
 
-kanawha:G5.p13 a rascat:RasPlan ;
+kanawha_models:G5.p13 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasGeometry kanawha:G5.g01 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u08 .
+    rascat:hasGeometry kanawha_models:G5.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u08 .
 
-kanawha:G5.p14 a rascat:RasPlan ;
+kanawha_models:G5.p14 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasGeometry kanawha:G5.g02 ;
-    rascat:hasUnsteadyFlow kanawha:G5.u10 .
+    rascat:hasGeometry kanawha_models:G5.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:G5.u10 .
 
-kanawha:G5.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:G5.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Initial Conditions" .
 
-kanawha:GSummersville_B.p01 a rascat:RasPlan ;
+kanawha_models:GSummersville_B.p01 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -5e-02 ;
             rascat:pbias 1.29e+00 ;
@@ -1163,6 +1109,7 @@ kanawha:GSummersville_B.p01 a rascat:RasPlan ;
             rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03187500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -3.91e+00 ;
@@ -1171,38 +1118,63 @@ kanawha:GSummersville_B.p01 a rascat:RasPlan ;
             rascat:rsr 2.22e+00 ;
             rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 6e-01 ;
-            rascat:pbias -2e-01 ;
-            rascat:r2 7.4e-01 ;
-            rascat:rsr 6.4e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03187000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -7.7e-01 ;
             rascat:pbias -1.7e-01 ;
             rascat:r2 6e-01 ;
             rascat:rsr 1.33e+00 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GSummersville_B.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_B.u05 .
+            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
+            rascat:fromStreamgage usgs_gages:03189100 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 6e-01 ;
+            rascat:pbias -2e-01 ;
+            rascat:r2 7.4e-01 ;
+            rascat:rsr 6.4e-01 ;
+            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u05 .
 
-kanawha:GSummersville_B.p02 a rascat:RasPlan ;
+kanawha_models:GSummersville_B.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03187500 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse 5.74e-01 ;
-            rascat:pbias 1.181e+00 ;
-            rascat:r2 6.07e-01 ;
-            rascat:rsr 6.53e-01 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
+            rascat:nse -4.1e-01 ;
+            rascat:pbias -7e-02 ;
+            rascat:r2 9.1e-01 ;
+            rascat:rsr 1.19e+00 ;
+            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03186500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 8.6e-01 ;
+            rascat:pbias 2.608e+01 ;
+            rascat:r2 9.6e-01 ;
+            rascat:rsr 3.7e-01 ;
+            rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03187000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 4.3e-01 ;
+            rascat:pbias -1.3e-01 ;
+            rascat:r2 9.1e-01 ;
+            rascat:rsr 7.5e-01 ;
+            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03187500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 9.5e-01 ;
@@ -1212,15 +1184,7 @@ kanawha:GSummersville_B.p02 a rascat:RasPlan ;
             rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03186500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.6e-01 ;
-            rascat:pbias 2.608e+01 ;
-            rascat:r2 9.6e-01 ;
-            rascat:rsr 3.7e-01 ;
-            rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03189100 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 8.8e-01 ;
@@ -1230,89 +1194,30 @@ kanawha:GSummersville_B.p02 a rascat:RasPlan ;
             rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -4.1e-01 ;
-            rascat:pbias -7e-02 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 1.19e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 4.3e-01 ;
-            rascat:pbias -1.3e-01 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 7.5e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 7.7e-01 ;
             rascat:pbias 5e-02 ;
             rascat:r2 8.7e-01 ;
             rascat:rsr 4.8e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GSummersville_B.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_B.u01 .
-
-kanawha:GSummersville_B.p11 a rascat:RasPlan ;
-    dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.5e-01 ;
-            rascat:pbias -8e-02 ;
-            rascat:r2 8.3e-01 ;
-            rascat:rsr 5e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03186500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.6e-01 ;
-            rascat:pbias -4.63e+00 ;
-            rascat:r2 9.6e-01 ;
-            rascat:rsr 1.9e-01 ;
-            rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.1e-01 ;
-            rascat:pbias -1e-02 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 3.1e-01 ;
             rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.1e-01 ;
-            rascat:pbias 1.609e+01 ;
-            rascat:r2 9.2e-01 ;
-            rascat:rsr 3e-01 ;
-            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.2e-01 ;
-            rascat:pbias 1.2e+00 ;
-            rascat:r2 8.7e-01 ;
-            rascat:rsr 5.3e-01 ;
-            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
             rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias -1.1e-01 ;
-            rascat:r2 9.3e-01 ;
-            rascat:rsr 3.4e-01 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
+            rascat:nse 5.74e-01 ;
+            rascat:pbias 1.181e+00 ;
+            rascat:r2 6.07e-01 ;
+            rascat:rsr 6.53e-01 ;
+            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u01 .
+
+kanawha_models:GSummersville_B.p11 a rascat:RasPlan ;
+    dcterms:title "Unsteady_MultiHazard_Jun2016" ;
+    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03189100 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 9.6e-01 ;
@@ -1322,6 +1227,65 @@ kanawha:GSummersville_B.p11 a rascat:RasPlan ;
             rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03189100 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 9.1e-01 ;
+            rascat:pbias -1e-02 ;
+            rascat:r2 9.1e-01 ;
+            rascat:rsr 3.1e-01 ;
+            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 9.1e-01 ;
+            rascat:pbias 1.609e+01 ;
+            rascat:r2 9.2e-01 ;
+            rascat:rsr 3e-01 ;
+            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03187000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 7.5e-01 ;
+            rascat:pbias -8e-02 ;
+            rascat:r2 8.3e-01 ;
+            rascat:rsr 5e-01 ;
+            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03186500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 9.6e-01 ;
+            rascat:pbias -4.63e+00 ;
+            rascat:r2 9.6e-01 ;
+            rascat:rsr 1.9e-01 ;
+            rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 8.8e-01 ;
+            rascat:pbias -1.1e-01 ;
+            rascat:r2 9.3e-01 ;
+            rascat:rsr 3.4e-01 ;
+            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03187500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 7.2e-01 ;
+            rascat:pbias 1.2e+00 ;
+            rascat:r2 8.7e-01 ;
+            rascat:rsr 5.3e-01 ;
+            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03187500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -1.33e+00 ;
@@ -1329,22 +1293,23 @@ kanawha:GSummersville_B.p11 a rascat:RasPlan ;
             rascat:r2 8.4e-01 ;
             rascat:rsr 1.53e+00 ;
             rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GSummersville_B.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_B.u07 .
+    rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u07 .
 
-kanawha:GSummersville_B.p12 a rascat:RasPlan ;
+kanawha_models:GSummersville_B.p12 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
+            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias 3e-02 ;
+            rascat:nse -2e-01 ;
+            rascat:pbias -2.7e-01 ;
             rascat:r2 9.8e-01 ;
-            rascat:rsr 3.4e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
+            rascat:rsr 1.05e+00 ;
+            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03187000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -3.8e-01 ;
@@ -1353,47 +1318,33 @@ kanawha:GSummersville_B.p12 a rascat:RasPlan ;
             rascat:rsr 1.18e+00 ;
             rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2e-01 ;
-            rascat:pbias -2.7e-01 ;
-            rascat:r2 9.8e-01 ;
-            rascat:rsr 1.05e+00 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03187500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -3.13e+00 ;
             rascat:pbias -7e-02 ;
             rascat:r2 8.9e-01 ;
             rascat:rsr 2.03e+00 ;
+            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03189100 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 8.8e-01 ;
+            rascat:pbias 3e-02 ;
+            rascat:r2 9.8e-01 ;
+            rascat:rsr 3.4e-01 ;
             rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GSummersville_B.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_B.u03 .
+    rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u03 .
 
-kanawha:GSummersville_C.p02 a rascat:RasPlan ;
+kanawha_models:GSummersville_C.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.2e-01 ;
-            rascat:pbias 1e-02 ;
-            rascat:r2 9.2e-01 ;
-            rascat:rsr 2.9e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8e-01 ;
-            rascat:pbias 5.039e+01 ;
-            rascat:r2 8.8e-01 ;
-            rascat:rsr 4.5e-01 ;
-            rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03189100 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 8.1e-01 ;
@@ -1402,15 +1353,18 @@ kanawha:GSummersville_C.p02 a rascat:RasPlan ;
             rascat:rsr 4.4e-01 ;
             rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03187000 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse 7.2e-01 ;
-            rascat:pbias 5e-02 ;
-            rascat:r2 8.6e-01 ;
-            rascat:rsr 5.3e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
+            rascat:nse 9.2e-01 ;
+            rascat:pbias 1e-02 ;
+            rascat:r2 9.2e-01 ;
+            rascat:rsr 2.9e-01 ;
+            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03186500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 8.8e-01 ;
@@ -1419,7 +1373,18 @@ kanawha:GSummersville_C.p02 a rascat:RasPlan ;
             rascat:rsr 3.5e-01 ;
             rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
+            rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03187500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 8e-01 ;
+            rascat:pbias 5.039e+01 ;
+            rascat:r2 8.8e-01 ;
+            rascat:rsr 4.5e-01 ;
+            rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
             rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 8.8e-01 ;
             rascat:pbias 3e-02 ;
@@ -1428,47 +1393,40 @@ kanawha:GSummersville_C.p02 a rascat:RasPlan ;
             rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03187500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 6.6e-01 ;
             rascat:pbias -2e-02 ;
             rascat:r2 8.9e-01 ;
             rascat:rsr 5.9e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_C.u03 .
-
-kanawha:GSummersville_C.p03 a rascat:RasPlan ;
-    dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.2e-01 ;
-            rascat:pbias 1.849e+01 ;
-            rascat:r2 9.3e-01 ;
-            rascat:rsr 2.9e-01 ;
-            rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.4e-01 ;
-            rascat:pbias 1e-02 ;
-            rascat:r2 8.6e-01 ;
-            rascat:rsr 4.1e-01 ;
             rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
+            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse 7e-01 ;
+            rascat:nse 7.2e-01 ;
             rascat:pbias 5e-02 ;
-            rascat:r2 7.4e-01 ;
-            rascat:rsr 5.4e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
+            rascat:r2 8.6e-01 ;
+            rascat:rsr 5.3e-01 ;
+            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u03 .
+
+kanawha_models:GSummersville_C.p03 a rascat:RasPlan ;
+    dcterms:title "Unsteady_MultiHazard_Jun2016" ;
+    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 8.8e-01 ;
+            rascat:pbias 1.599e+01 ;
+            rascat:r2 8.9e-01 ;
+            rascat:rsr 3.4e-01 ;
+            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03187500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 1e-02 ;
@@ -1477,16 +1435,8 @@ kanawha:GSummersville_C.p03 a rascat:RasPlan ;
             rascat:rsr 1e+00 ;
             rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.2e-01 ;
-            rascat:pbias 1.755e+01 ;
-            rascat:r2 8.2e-01 ;
-            rascat:rsr 5.2e-01 ;
-            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03186500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 9.4e-01 ;
@@ -1495,42 +1445,86 @@ kanawha:GSummersville_C.p03 a rascat:RasPlan ;
             rascat:rsr 2.5e-01 ;
             rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias 1.599e+01 ;
-            rascat:r2 8.9e-01 ;
-            rascat:rsr 3.4e-01 ;
-            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
             rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 8.7e-01 ;
             rascat:pbias 2.8e-01 ;
             rascat:r2 9.9e-01 ;
             rascat:rsr 3.5e-01 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_C.u04 .
-
-kanawha:GSummersville_C.p04 a rascat:RasPlan ;
-    dcterms:title "Unsteady_MultiHazard_Nov2003-RF" ;
-    rascat:hasGeometry kanawha:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_C.u03 .
-
-kanawha:GSummersville_C.p05 a rascat:RasPlan ;
-    dcterms:title "Unsteady_MultiHazard_Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 4.9e-01 ;
-            rascat:pbias 3e-02 ;
-            rascat:r2 7.7e-01 ;
-            rascat:rsr 7.1e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
+            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03189100 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 8.4e-01 ;
+            rascat:pbias 1e-02 ;
+            rascat:r2 8.6e-01 ;
+            rascat:rsr 4.1e-01 ;
+            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03187500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 7.2e-01 ;
+            rascat:pbias 1.755e+01 ;
+            rascat:r2 8.2e-01 ;
+            rascat:rsr 5.2e-01 ;
+            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03187000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 7e-01 ;
+            rascat:pbias 5e-02 ;
+            rascat:r2 7.4e-01 ;
+            rascat:rsr 5.4e-01 ;
+            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03189100 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 9.2e-01 ;
+            rascat:pbias 1.849e+01 ;
+            rascat:r2 9.3e-01 ;
+            rascat:rsr 2.9e-01 ;
+            rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u04 .
+
+kanawha_models:GSummersville_C.p04 a rascat:RasPlan ;
+    dcterms:title "Unsteady_MultiHazard_Nov2003-RF" ;
+    rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u03 .
+
+kanawha_models:GSummersville_C.p05 a rascat:RasPlan ;
+    dcterms:title "Unsteady_MultiHazard_Jan1995" ;
+    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03187000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse -1e-02 ;
+            rascat:pbias 6e-02 ;
+            rascat:r2 5.7e-01 ;
+            rascat:rsr 1e+00 ;
+            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse -2.46e+00 ;
+            rascat:pbias 4.1e-01 ;
+            rascat:r2 8.2e-01 ;
+            rascat:rsr 1.86e+00 ;
+            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03187500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -3e-02 ;
@@ -1539,34 +1533,47 @@ kanawha:GSummersville_C.p05 a rascat:RasPlan ;
             rascat:rsr 1.01e+00 ;
             rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03189100 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse -2.46e+00 ;
-            rascat:pbias 4.1e-01 ;
-            rascat:r2 8.2e-01 ;
-            rascat:rsr 1.86e+00 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1e-02 ;
-            rascat:pbias 6e-02 ;
-            rascat:r2 5.7e-01 ;
-            rascat:rsr 1e+00 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_C.u05 .
+            rascat:nse 4.9e-01 ;
+            rascat:pbias 3e-02 ;
+            rascat:r2 7.7e-01 ;
+            rascat:rsr 7.1e-01 ;
+            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u05 .
 
-kanawha:GSummersville_C.p06 a rascat:RasPlan ;
+kanawha_models:GSummersville_C.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995-RF" ;
-    rascat:hasGeometry kanawha:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_C.u05 .
+    rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u05 .
 
-kanawha:GSummersville_C.p07 a rascat:RasPlan ;
+kanawha_models:GSummersville_C.p07 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
+            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse -2.1e-01 ;
+            rascat:pbias 1.4e+00 ;
+            rascat:r2 6.4e-01 ;
+            rascat:rsr 1.1e+00 ;
+            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
+            rascat:fromStreamgage usgs_gages:03187500 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse -1.53e+00 ;
+            rascat:pbias -8e-02 ;
+            rascat:r2 7e-01 ;
+            rascat:rsr 1.59e+00 ;
+            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03189100 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 5.5e-01 ;
@@ -1576,46 +1583,22 @@ kanawha:GSummersville_C.p07 a rascat:RasPlan ;
             rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03187000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 4.9e-01 ;
             rascat:pbias -6e-02 ;
             rascat:r2 6.6e-01 ;
             rascat:rsr 7.1e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2.1e-01 ;
-            rascat:pbias 1.4e+00 ;
-            rascat:r2 6.4e-01 ;
-            rascat:rsr 1.1e+00 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1.53e+00 ;
-            rascat:pbias -8e-02 ;
-            rascat:r2 7e-01 ;
-            rascat:rsr 1.59e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GSummersville_C.u06 .
+            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u06 .
 
-kanawha:GauleyLower_BLE_FEM.p01 a rascat:RasPlan ;
+kanawha_models:GauleyLower_BLE_FEM.p01 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03191500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 5.74e-01 ;
-            rascat:pbias 1.181e+00 ;
-            rascat:r2 6.07e-01 ;
-            rascat:rsr 6.53e-01 ;
-            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-12-31T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03192000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 5.93e-01 ;
@@ -1625,52 +1608,57 @@ kanawha:GauleyLower_BLE_FEM.p01 a rascat:RasPlan ;
             rascat:startDateTime "2003-09-30T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-09-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03192000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 6.25e-01 ;
             rascat:pbias -1.82e-01 ;
             rascat:r2 7.84e-01 ;
             rascat:rsr 6.12e-01 ;
-            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GauleyLower_BLE_FEM.u01 .
-
-kanawha:GauleyLower_BLE_FEM.p02 a rascat:RasPlan ;
-    dcterms:title "Unsteady_MultiHazard_Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.52e-01 ;
-            rascat:pbias -1.5726e+00 ;
-            rascat:r2 9.62e-01 ;
-            rascat:rsr 2.18e-01 ;
-            rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime ],
+            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03191500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 5.74e-01 ;
+            rascat:pbias 1.181e+00 ;
+            rascat:r2 6.07e-01 ;
+            rascat:rsr 6.53e-01 ;
+            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u01 .
+
+kanawha_models:GauleyLower_BLE_FEM.p02 a rascat:RasPlan ;
+    dcterms:title "Unsteady_MultiHazard_Jan1995" ;
+    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03192000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 4.88e-01 ;
             rascat:pbias -1.95e-01 ;
             rascat:r2 9.59e-01 ;
             rascat:rsr 7.15e-01 ;
-            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GauleyLower_BLE_FEM.u03 .
-
-kanawha:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
-    dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.82e-01 ;
-            rascat:pbias -2.01e-01 ;
-            rascat:r2 8.76e-01 ;
-            rascat:rsr 4.67e-01 ;
             rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
+            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03192000 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 9.52e-01 ;
+            rascat:pbias -1.5726e+00 ;
+            rascat:r2 9.62e-01 ;
+            rascat:rsr 2.18e-01 ;
+            rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u03 .
+
+kanawha_models:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
+    dcterms:title "Unsteady_MultiHazard_Jun2016" ;
+    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-31T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03192000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 9.13e-01 ;
@@ -1680,6 +1668,27 @@ kanawha:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
             rascat:startDateTime "2016-04-30T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03192000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 7.82e-01 ;
+            rascat:pbias -2.01e-01 ;
+            rascat:r2 8.76e-01 ;
+            rascat:rsr 4.67e-01 ;
+            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03191500 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 6.67e-01 ;
+            rascat:pbias 1.26e+01 ;
+            rascat:r2 6.7e-01 ;
+            rascat:rsr 5.77e-01 ;
+            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03190000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 9.12e-01 ;
@@ -1689,101 +1698,97 @@ kanawha:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
             rascat:startDateTime "2014-04-02T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03191500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.67e-01 ;
-            rascat:pbias 1.26e+01 ;
-            rascat:r2 6.7e-01 ;
-            rascat:rsr 5.77e-01 ;
-            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03190000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.59e-01 ;
-            rascat:pbias -1.1652e+01 ;
-            rascat:r2 8.78e-01 ;
-            rascat:rsr 3.76e-01 ;
-            rascat:startDateTime "2012-08-30T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03191500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 6.91e-01 ;
             rascat:pbias 3.1e-02 ;
             rascat:r2 8.96e-01 ;
             rascat:rsr 5.56e-01 ;
-            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GauleyLower_BLE_FEM.u02 .
+            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03190000 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 8.59e-01 ;
+            rascat:pbias -1.1652e+01 ;
+            rascat:r2 8.78e-01 ;
+            rascat:rsr 3.76e-01 ;
+            rascat:startDateTime "2012-08-30T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u02 .
 
-kanawha:GauleyLower_BLE_FEM.p06 a rascat:RasPlan ;
+kanawha_models:GauleyLower_BLE_FEM.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.49e-01 ;
-            rascat:pbias 2.4806e+01 ;
-            rascat:r2 7.85e-01 ;
-            rascat:rsr 5.93e-01 ;
-            rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03192000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 8.28e-01 ;
             rascat:pbias -9.6e-02 ;
             rascat:r2 8.75e-01 ;
             rascat:rsr 4.15e-01 ;
-            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasUnsteadyFlow kanawha:GauleyLower_BLE_FEM.u04 .
+            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
+            rascat:fromStreamgage usgs_gages:03192000 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 6.49e-01 ;
+            rascat:pbias 2.4806e+01 ;
+            rascat:r2 7.85e-01 ;
+            rascat:rsr 5.93e-01 ;
+            rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u04 .
 
-kanawha:Greenbrier_G7.p01 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G7.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Greenbrier_G7.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G7.u01 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G7.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u01 .
 
-kanawha:Greenbrier_G7.p03 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G7.p03 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Greenbrier_G7.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G7.u03 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G7.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u03 .
 
-kanawha:Greenbrier_G7.p04 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G7.p04 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasGeometry kanawha:Greenbrier_G7.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G7.u04 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G7.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u04 .
 
-kanawha:Greenbrier_G7.p05 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G7.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasGeometry kanawha:Greenbrier_G7.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G7.u05 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G7.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u05 .
 
-kanawha:Greenbrier_G7.p06 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G7.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasGeometry kanawha:Greenbrier_G7.g03 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G7.u06 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G7.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u06 .
 
-kanawha:Greenbrier_G7.p07 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G7.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasGeometry kanawha:Greenbrier_G7.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G7.u07 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G7.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u07 .
 
-kanawha:Greenbrier_G8.p01 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G8.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Greenbrier_G8.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G8.u01 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u01 .
 
-kanawha:Greenbrier_G8.p03 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G8.p03 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Greenbrier_G8.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G8.u03 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G8.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u03 .
 
-kanawha:Greenbrier_G8.p04 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G8.p04 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03183500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 8.6125e-01 ;
@@ -1791,13 +1796,14 @@ kanawha:Greenbrier_G8.p04 a rascat:RasPlan ;
             rascat:r2 9.0781e-01 ;
             rascat:rsr 3.7249e-01 ;
             rascat:startDateTime "2016-04-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Greenbrier_G8.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G8.u04 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u04 .
 
-kanawha:Greenbrier_G8.p05 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G8.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03183500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -1.8586e+00 ;
@@ -1805,13 +1811,14 @@ kanawha:Greenbrier_G8.p05 a rascat:RasPlan ;
             rascat:r2 4.2492e-01 ;
             rascat:rsr 1.6907e+00 ;
             rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Greenbrier_G8.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G8.u05 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u05 .
 
-kanawha:Greenbrier_G8.p06 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G8.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03183500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -9.5796e-01 ;
@@ -1819,13 +1826,14 @@ kanawha:Greenbrier_G8.p06 a rascat:RasPlan ;
             rascat:r2 5.4692e-01 ;
             rascat:rsr 1.3993e+00 ;
             rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Greenbrier_G8.g03 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G8.u06 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G8.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u06 .
 
-kanawha:Greenbrier_G8.p07 a rascat:RasPlan ;
+kanawha_models:Greenbrier_G8.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-12-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03183500 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 7.5762e-01 ;
@@ -1833,40 +1841,41 @@ kanawha:Greenbrier_G8.p07 a rascat:RasPlan ;
             rascat:r2 9.363e-01 ;
             rascat:rsr 4.9232e-01 ;
             rascat:startDateTime "2003-09-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Greenbrier_G8.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Greenbrier_G8.u07 .
+    rascat:hasGeometry kanawha_models:Greenbrier_G8.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u07 .
 
-kanawha:Greenbrier_G8.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G8.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996" .
 
-kanawha:Kanawha_G1.p01 a rascat:RasPlan ;
+kanawha_models:Kanawha_G1.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u01 .
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u01 .
 
-kanawha:Kanawha_G1.p02 a rascat:RasPlan ;
+kanawha_models:Kanawha_G1.p02 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g03 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u02 .
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u02 .
 
-kanawha:Kanawha_G1.p03 a rascat:RasPlan ;
+kanawha_models:Kanawha_G1.p03 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u03 .
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u03 .
 
-kanawha:Kanawha_G1.p04 a rascat:RasPlan ;
+kanawha_models:Kanawha_G1.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u04 .
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u04 .
 
-kanawha:Kanawha_G1.p05 a rascat:RasPlan ;
+kanawha_models:Kanawha_G1.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03180500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse -1.7704e-01 ;
@@ -1874,13 +1883,14 @@ kanawha:Kanawha_G1.p05 a rascat:RasPlan ;
             rascat:r2 8.9384e-01 ;
             rascat:rsr 1.0849e+00 ;
             rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u05 .
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u05 .
 
-kanawha:Kanawha_G1.p06 a rascat:RasPlan ;
+kanawha_models:Kanawha_G1.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03180500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 4.3346e-01 ;
@@ -1888,13 +1898,14 @@ kanawha:Kanawha_G1.p06 a rascat:RasPlan ;
             rascat:r2 9.242e-01 ;
             rascat:rsr 7.5269e-01 ;
             rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g03 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u06 .
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u06 .
 
-kanawha:Kanawha_G1.p07 a rascat:RasPlan ;
+kanawha_models:Kanawha_G1.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03180500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 3.1295e-01 ;
@@ -1902,13 +1913,14 @@ kanawha:Kanawha_G1.p07 a rascat:RasPlan ;
             rascat:r2 8.1655e-01 ;
             rascat:rsr 8.2889e-01 ;
             rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u07 .
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u07 .
 
-kanawha:Kanawha_G1.p08 a rascat:RasPlan ;
+kanawha_models:Kanawha_G1.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03180500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 4.5906e-01 ;
@@ -1916,77 +1928,79 @@ kanawha:Kanawha_G1.p08 a rascat:RasPlan ;
             rascat:r2 7.3227e-01 ;
             rascat:rsr 7.3549e-01 ;
             rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:Kanawha_G1.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G1.u08 .
+    rascat:hasGeometry kanawha_models:Kanawha_G1.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u08 .
 
-kanawha:Kanawha_G2.p01 a rascat:RasPlan ;
+kanawha_models:Kanawha_G2.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u01 .
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u01 .
 
-kanawha:Kanawha_G2.p02 a rascat:RasPlan ;
+kanawha_models:Kanawha_G2.p02 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u02 .
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u02 .
 
-kanawha:Kanawha_G2.p03 a rascat:RasPlan ;
+kanawha_models:Kanawha_G2.p03 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u03 .
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u03 .
 
-kanawha:Kanawha_G2.p04 a rascat:RasPlan ;
+kanawha_models:Kanawha_G2.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u04 .
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u04 .
 
-kanawha:Kanawha_G2.p05 a rascat:RasPlan ;
+kanawha_models:Kanawha_G2.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u05 .
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u05 .
 
-kanawha:Kanawha_G2.p06 a rascat:RasPlan ;
+kanawha_models:Kanawha_G2.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g03 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u06 .
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u06 .
 
-kanawha:Kanawha_G2.p07 a rascat:RasPlan ;
+kanawha_models:Kanawha_G2.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u07 .
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u07 .
 
-kanawha:Kanawha_G2.p08 a rascat:RasPlan ;
+kanawha_models:Kanawha_G2.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasGeometry kanawha:Kanawha_G2.g02 ;
-    rascat:hasUnsteadyFlow kanawha:Kanawha_G2.u08 .
+    rascat:hasGeometry kanawha_models:Kanawha_G2.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u08 .
 
-kanawha:New-LittleRiver.p05 a rascat:RasPlan ;
+kanawha_models:New-LittleRiver.p05 a rascat:RasPlan ;
     dcterms:title "JUN2016_HMS" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03170000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 3.5e-01 ;
-            rascat:pbias 1.411e+01 ;
-            rascat:r2 6.4e-01 ;
-            rascat:rsr 8.1e-01 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03171000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -3.1e-01 ;
             rascat:pbias 1.955e+01 ;
             rascat:r2 1e-02 ;
             rascat:rsr 1.14e+00 ;
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03170000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 3.5e-01 ;
+            rascat:pbias 1.411e+01 ;
+            rascat:r2 6.4e-01 ;
+            rascat:rsr 8.1e-01 ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:New-LittleRiver.u05 .
+    rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u05 .
 
-kanawha:New-LittleRiver.p06 a rascat:RasPlan ;
+kanawha_models:New-LittleRiver.p06 a rascat:RasPlan ;
     dcterms:description """with rating curve at dam and initial condition
 bigger channels 
 lower overland Manning's n values
@@ -1997,57 +2011,62 @@ restart file""" ;
     dcterms:title "NOV2003_HMS" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03170000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.4e-01 ;
-            rascat:pbias 5.13e+00 ;
-            rascat:r2 9.4e-01 ;
-            rascat:rsr 2.5e-01 ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03171000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 3.8e-01 ;
             rascat:pbias 9.42e+00 ;
             rascat:r2 3.9e-01 ;
             rascat:rsr 7.9e-01 ;
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03170000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 9.4e-01 ;
+            rascat:pbias 5.13e+00 ;
+            rascat:r2 9.4e-01 ;
+            rascat:rsr 2.5e-01 ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:New-LittleRiver.u08 .
+    rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u08 .
 
-kanawha:New-LittleRiver.p07 a rascat:RasPlan ;
+kanawha_models:New-LittleRiver.p07 a rascat:RasPlan ;
     dcterms:title "JAN1996_HMS" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03171000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 5.6e-01 ;
-            rascat:pbias 1.31e+00 ;
-            rascat:r2 5.6e-01 ;
-            rascat:rsr 6.6e-01 ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03170000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 9e-01 ;
             rascat:pbias -2.86e+00 ;
             rascat:r2 9.5e-01 ;
             rascat:rsr 3.2e-01 ;
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
+            rascat:fromStreamgage usgs_gages:03171000 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 5.6e-01 ;
+            rascat:pbias 1.31e+00 ;
+            rascat:r2 5.6e-01 ;
+            rascat:rsr 6.6e-01 ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:New-LittleRiver.u07 .
+    rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u07 .
 
-kanawha:New-LittleRiver.p17 a rascat:RasPlan ;
+kanawha_models:New-LittleRiver.p17 a rascat:RasPlan ;
     dcterms:title "restart_file" ;
-    rascat:hasGeometry kanawha:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:New-LittleRiver.u09 .
+    rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u09 .
 
-kanawha:New-LittleRiver.p19 a rascat:RasPlan ;
+kanawha_models:New-LittleRiver.p19 a rascat:RasPlan ;
     dcterms:title "JAN1995_HMS" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03171000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 5.7e-01 ;
@@ -2057,6 +2076,7 @@ kanawha:New-LittleRiver.p19 a rascat:RasPlan ;
             rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03170000 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 9.5e-01 ;
@@ -2064,28 +2084,30 @@ kanawha:New-LittleRiver.p19 a rascat:RasPlan ;
             rascat:r2 9.6e-01 ;
             rascat:rsr 2.2e-01 ;
             rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha:New-LittleRiver.u10 .
+    rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u10 .
 
-kanawha:UpperKanawha.p01 a rascat:RasPlan ;
+kanawha_models:UpperKanawha.p01 a rascat:RasPlan ;
     dcterms:description """Geometry: Upper Kanawha BLE geometry. Includes Marmet and London L&D. Gate operations from Kanawha CWMS. 
 Flow: June 2016 AORC gridded precipitation. Upstream inflow from USGS Kanawha Falls. Downstream time-stage translated to model outlet from USGS Charleston gage based on friction slope.
 Initial Conditions: Restart file from p.03""" ;
     dcterms:title "Jun2016" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "Marmet L&D Tailwater" ;
+            dcterms:title "London L&D Tailwater" ;
             rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse 9.2097e-01 ;
-            rascat:pbias 1.2004e-01 ;
-            rascat:r2 9.2979e-01 ;
-            rascat:rsr 2.8112e-01 ;
+            rascat:nse 9.6292e-01 ;
+            rascat:pbias -1.3638e-01 ;
+            rascat:r2 9.8229e-01 ;
+            rascat:rsr 1.9255e-01 ;
             rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
             dcterms:title "London L&D Pool" ;
             rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -1.807e+02 ;
             rascat:pbias -2.696e-01 ;
@@ -2094,56 +2116,39 @@ Initial Conditions: Restart file from p.03""" ;
             rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "London L&D Tailwater" ;
+            dcterms:title "Marmet L&D Tailwater" ;
             rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:hydrographType "Stage" ;
-            rascat:nse 9.6292e-01 ;
-            rascat:pbias -1.3638e-01 ;
-            rascat:r2 9.8229e-01 ;
-            rascat:rsr 1.9255e-01 ;
+            rascat:nse 9.2097e-01 ;
+            rascat:pbias 1.2004e-01 ;
+            rascat:r2 9.2979e-01 ;
+            rascat:rsr 2.8112e-01 ;
             rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             dcterms:description "Stage hydrograph provided by USACE." ;
             dcterms:title "Marmet L&D Pool" ;
             rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 4.3975e-01 ;
             rascat:pbias 7.278e-02 ;
             rascat:r2 5.7783e-01 ;
             rascat:rsr 7.485e-01 ;
             rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperKanawha.u11 .
+    rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u11 .
 
-kanawha:UpperKanawha.p02 a rascat:RasPlan ;
+kanawha_models:UpperKanawha.p02 a rascat:RasPlan ;
     dcterms:description """Geometry: Upper Kanawha BLE geometry. Includes Marmet and London L&D. Gate operations from Kanawha CWMS. 
 Flow: Nov 2003 AORC gridded precipitation. Upstream inflow from USGS Kanawha Falls. Downstream time-stage translated to model outlet from USGS Charleston gage based on friction slope.
 Initial Conditions: Restart file from p.04""" ;
     dcterms:title "Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "Marmet L&D Tailwater" ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.0228e-01 ;
-            rascat:pbias 6.1883e-02 ;
-            rascat:r2 8.096e-01 ;
-            rascat:rsr 4.4465e-01 ;
-            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "London L&D Tailwater" ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.4446e-01 ;
-            rascat:pbias -1.4871e-01 ;
-            rascat:r2 9.8069e-01 ;
-            rascat:rsr 2.3567e-01 ;
-            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE." ;
             dcterms:title "Marmet L&D Pool" ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:hydrographType "Stage" ;
             rascat:nse 8.3132e-01 ;
             rascat:pbias 2.3509e-02 ;
@@ -2154,47 +2159,71 @@ Initial Conditions: Restart file from p.04""" ;
             dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
             dcterms:title "London L&D Pool" ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:hydrographType "Stage" ;
             rascat:nse -5.0493e+01 ;
             rascat:pbias -1.8653e-01 ;
             rascat:r2 2.2156e-01 ;
             rascat:rsr 7.1759e+00 ;
+            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            dcterms:description "Stage hydrograph provided by USACE." ;
+            dcterms:title "London L&D Tailwater" ;
+            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 9.4446e-01 ;
+            rascat:pbias -1.4871e-01 ;
+            rascat:r2 9.8069e-01 ;
+            rascat:rsr 2.3567e-01 ;
+            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            dcterms:description "Stage hydrograph provided by USACE." ;
+            dcterms:title "Marmet L&D Tailwater" ;
+            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:hydrographType "Stage" ;
+            rascat:nse 8.0228e-01 ;
+            rascat:pbias 6.1883e-02 ;
+            rascat:r2 8.096e-01 ;
+            rascat:rsr 4.4465e-01 ;
             rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperKanawha.u08 .
+    rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u08 .
 
-kanawha:UpperKanawha.p03 a rascat:RasPlan ;
+kanawha_models:UpperKanawha.p03 a rascat:RasPlan ;
     dcterms:title "Jun2016_InitialConditions" ;
-    rascat:hasGeometry kanawha:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperKanawha.u09 .
+    rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u09 .
 
-kanawha:UpperKanawha.p04 a rascat:RasPlan ;
+kanawha_models:UpperKanawha.p04 a rascat:RasPlan ;
     dcterms:title "Nov2003_InitialConditions" ;
-    rascat:hasGeometry kanawha:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperKanawha.u07 .
+    rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u07 .
 
-kanawha:UpperKanawha.p05 a rascat:RasPlan ;
+kanawha_models:UpperKanawha.p05 a rascat:RasPlan ;
     dcterms:description """Geometry: Upper Kanawha BLE geometry. Includes Marmet and London L&D. Gate operations from Kanawha CWMS. 
 Flow: Jan 1996 AORC gridded precipitation. Upstream inflow from USGS Kanawha Falls. Downstream time-stage (daily average flow, converted to stage via Charleston rating curve) translated to model outlet from USGS Charleston gage based on friction slope.
 Initial Conditions: Restart file from p.06""" ;
     dcterms:title "Jan1996" ;
-    rascat:hasGeometry kanawha:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperKanawha.u01 .
+    rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u01 .
 
-kanawha:UpperKanawha.p06 a rascat:RasPlan ;
+kanawha_models:UpperKanawha.p06 a rascat:RasPlan ;
     dcterms:title "Jan1996_InitialConditions" ;
-    rascat:hasGeometry kanawha:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperKanawha.u02 .
+    rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u02 .
 
-kanawha:UpperNew_Lower.p01 a rascat:RasPlan ;
+kanawha_models:UpperNew_Lower.p01 a rascat:RasPlan ;
     dcterms:title "Restart" ;
-    rascat:hasGeometry kanawha:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Lower.u01 .
+    rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u01 .
 
-kanawha:UpperNew_Lower.p02 a rascat:RasPlan ;
+kanawha_models:UpperNew_Lower.p02 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03168000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 9.24e-01 ;
@@ -2202,16 +2231,17 @@ kanawha:UpperNew_Lower.p02 a rascat:RasPlan ;
             rascat:r2 9.78e-01 ;
             rascat:rsr 2.76e-01 ;
             rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Lower.u02 .
+    rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u02 .
 
-kanawha:UpperNew_Lower.p03 a rascat:RasPlan ;
+kanawha_models:UpperNew_Lower.p03 a rascat:RasPlan ;
     dcterms:description """Start time had to change from 14JAN1996 1200 to 19JAN1996 0500 due to a gap in the Upper New - Galax gage record.
 
 Start time had to change from 07FEB1996 1200 to 02FEB1996 0400 due to a gap in the Upper New - Galax gage record.""" ;
     dcterms:title "Jan1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-02-02T04:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03168000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 3.03e-01 ;
@@ -2219,36 +2249,39 @@ Start time had to change from 07FEB1996 1200 to 02FEB1996 0400 due to a gap in t
             rascat:r2 3.26e-01 ;
             rascat:rsr 8.34e-01 ;
             rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Lower.u03 .
+    rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u03 .
 
-kanawha:UpperNew_Lower.p04 a rascat:RasPlan ;
+kanawha_models:UpperNew_Lower.p04 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03168000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.92e-01 ;
-            rascat:pbias 2.6041e+01 ;
-            rascat:r2 9.84e-01 ;
-            rascat:rsr 5.55e-01 ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03165500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 8.79e-01 ;
             rascat:pbias 7.498e+00 ;
             rascat:r2 9.35e-01 ;
             rascat:rsr 4.8e-01 ;
+            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
+            rascat:fromStreamgage usgs_gages:03168000 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 6.92e-01 ;
+            rascat:pbias 2.6041e+01 ;
+            rascat:r2 9.84e-01 ;
+            rascat:rsr 5.55e-01 ;
             rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Lower.u04 .
+    rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u04 .
 
-kanawha:UpperNew_Lower.p07 a rascat:RasPlan ;
+kanawha_models:UpperNew_Lower.p07 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03168000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse -3.43e-01 ;
@@ -2258,6 +2291,7 @@ kanawha:UpperNew_Lower.p07 a rascat:RasPlan ;
             rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03165500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 5.6e-01 ;
@@ -2265,36 +2299,39 @@ kanawha:UpperNew_Lower.p07 a rascat:RasPlan ;
             rascat:r2 7.23e-01 ;
             rascat:rsr 7.23e-01 ;
             rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Lower.u05 .
+    rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u05 .
 
-kanawha:UpperNew_Upper.p01 a rascat:RasPlan ;
+kanawha_models:UpperNew_Upper.p01 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03161000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.6e-01 ;
-            rascat:pbias -5.26e+00 ;
-            rascat:r2 9.7e-01 ;
-            rascat:rsr 2.1e-01 ;
-            rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03164000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 8.8e-01 ;
             rascat:pbias 2.077e+01 ;
             rascat:r2 9.1e-01 ;
             rascat:rsr 3.4e-01 ;
+            rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
+            rascat:fromStreamgage usgs_gages:03161000 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 9.6e-01 ;
+            rascat:pbias -5.26e+00 ;
+            rascat:r2 9.7e-01 ;
+            rascat:rsr 2.1e-01 ;
             rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperNew_Upper.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Upper.u01 .
+    rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u01 .
 
-kanawha:UpperNew_Upper.p02 a rascat:RasPlan ;
+kanawha_models:UpperNew_Upper.p02 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03161000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 9.7e-01 ;
@@ -2304,6 +2341,7 @@ kanawha:UpperNew_Upper.p02 a rascat:RasPlan ;
             rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ],
         [ a rascat:Hydrograph ;
             rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03164000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 6.2e-01 ;
@@ -2311,87 +2349,92 @@ kanawha:UpperNew_Upper.p02 a rascat:RasPlan ;
             rascat:r2 8e-01 ;
             rascat:rsr 6.2e-01 ;
             rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperNew_Upper.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Upper.u02 .
+    rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u02 .
 
-kanawha:UpperNew_Upper.p03 a rascat:RasPlan ;
+kanawha_models:UpperNew_Upper.p03 a rascat:RasPlan ;
     dcterms:title "Jan1996" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03161000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.6e-01 ;
-            rascat:pbias -2.61e+00 ;
-            rascat:r2 7.9e-01 ;
-            rascat:rsr 4.8e-01 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03164000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse -3.4e-01 ;
             rascat:pbias 5.675e+01 ;
             rascat:r2 3.3e-01 ;
             rascat:rsr 1.16e+00 ;
+            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
+            rascat:fromStreamgage usgs_gages:03161000 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse 7.6e-01 ;
+            rascat:pbias -2.61e+00 ;
+            rascat:r2 7.9e-01 ;
+            rascat:rsr 4.8e-01 ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperNew_Upper.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Upper.u03 .
+    rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u03 .
 
-kanawha:UpperNew_Upper.p04 a rascat:RasPlan ;
+kanawha_models:UpperNew_Upper.p04 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
-            rascat:fromStreamgage usgs_gages:03161000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -1.22e+00 ;
-            rascat:pbias -8.08e+00 ;
-            rascat:r2 2e-02 ;
-            rascat:rsr 1.49e+00 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03164000 ;
             rascat:hydrographType "Flow" ;
             rascat:nse -7.27e+00 ;
             rascat:pbias 5.876e+01 ;
             rascat:r2 1.4e-01 ;
             rascat:rsr 2.87e+00 ;
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
+        [ a rascat:Hydrograph ;
+            rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
+            rascat:fromStreamgage usgs_gages:03161000 ;
+            rascat:hydrographType "Flow" ;
+            rascat:nse -1.22e+00 ;
+            rascat:pbias -8.08e+00 ;
+            rascat:r2 2e-02 ;
+            rascat:rsr 1.49e+00 ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:UpperNew_Upper.g01 ;
-    rascat:hasUnsteadyFlow kanawha:UpperNew_Upper.u04 .
+    rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u04 .
 
-kanawha:UpperNew_Upper.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Upper.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "RestartFile" .
 
-kanawha:WatershedG3.p01 a rascat:RasPlan ;
+kanawha_models:WatershedG3.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG3.g02 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u05 .
+    rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u05 .
 
-kanawha:WatershedG3.p02 a rascat:RasPlan ;
+kanawha_models:WatershedG3.p02 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG3.g03 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u02 .
+    rascat:hasGeometry kanawha_models:WatershedG3.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u02 .
 
-kanawha:WatershedG3.p03 a rascat:RasPlan ;
+kanawha_models:WatershedG3.p03 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG3.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u03 .
+    rascat:hasGeometry kanawha_models:WatershedG3.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u03 .
 
-kanawha:WatershedG3.p04 a rascat:RasPlan ;
+kanawha_models:WatershedG3.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG3.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u04 .
+    rascat:hasGeometry kanawha_models:WatershedG3.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u04 .
 
-kanawha:WatershedG3.p05 a rascat:RasPlan ;
+kanawha_models:WatershedG3.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1995" ;
             rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:fromStreamgage usgs_gages:03182500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 1.3088e-01 ;
@@ -2399,14 +2442,15 @@ kanawha:WatershedG3.p05 a rascat:RasPlan ;
             rascat:r2 6.1693e-01 ;
             rascat:rsr 9.3227e-01 ;
             rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:WatershedG3.g02 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u01 .
+    rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u01 .
 
-kanawha:WatershedG3.p06 a rascat:RasPlan ;
+kanawha_models:WatershedG3.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1996" ;
             rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:fromStreamgage usgs_gages:03182500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 5.2781e-01 ;
@@ -2414,14 +2458,15 @@ kanawha:WatershedG3.p06 a rascat:RasPlan ;
             rascat:r2 9.1635e-01 ;
             rascat:rsr 6.8716e-01 ;
             rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:WatershedG3.g03 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u02 .
+    rascat:hasGeometry kanawha_models:WatershedG3.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u02 .
 
-kanawha:WatershedG3.p07 a rascat:RasPlan ;
+kanawha_models:WatershedG3.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in November 2003" ;
             rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:fromStreamgage usgs_gages:03182500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 6.3691e-01 ;
@@ -2429,14 +2474,15 @@ kanawha:WatershedG3.p07 a rascat:RasPlan ;
             rascat:r2 9.099e-01 ;
             rascat:rsr 6.0257e-01 ;
             rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:WatershedG3.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u03 .
+    rascat:hasGeometry kanawha_models:WatershedG3.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u03 .
 
-kanawha:WatershedG3.p08 a rascat:RasPlan ;
+kanawha_models:WatershedG3.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in June 2016" ;
             rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:fromStreamgage usgs_gages:03182500 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 9.627e-01 ;
@@ -2444,127 +2490,216 @@ kanawha:WatershedG3.p08 a rascat:RasPlan ;
             rascat:r2 9.8257e-01 ;
             rascat:rsr 1.9314e-01 ;
             rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:WatershedG3.g02 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG3.u04 .
+    rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u04 .
 
-kanawha:WatershedG4.p01 a rascat:RasPlan ;
+kanawha_models:WatershedG4.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u01 .
+    rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u01 .
 
-kanawha:WatershedG4.p02 a rascat:RasPlan ;
+kanawha_models:WatershedG4.p02 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u02 .
+    rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u02 .
 
-kanawha:WatershedG4.p03 a rascat:RasPlan ;
+kanawha_models:WatershedG4.p03 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u03 .
+    rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u03 .
 
-kanawha:WatershedG4.p04 a rascat:RasPlan ;
+kanawha_models:WatershedG4.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u04 .
+    rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u04 .
 
-kanawha:WatershedG4.p05 a rascat:RasPlan ;
+kanawha_models:WatershedG4.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasGeometry kanawha:WatershedG4.g02 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u01 .
+    rascat:hasGeometry kanawha_models:WatershedG4.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u01 .
 
-kanawha:WatershedG4.p06 a rascat:RasPlan ;
+kanawha_models:WatershedG4.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasGeometry kanawha:WatershedG4.g03 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u02 .
+    rascat:hasGeometry kanawha_models:WatershedG4.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u02 .
 
-kanawha:WatershedG4.p07 a rascat:RasPlan ;
+kanawha_models:WatershedG4.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasGeometry kanawha:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u03 .
+    rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u03 .
 
-kanawha:WatershedG4.p08 a rascat:RasPlan ;
+kanawha_models:WatershedG4.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasGeometry kanawha:WatershedG4.g02 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG4.u04 .
+    rascat:hasGeometry kanawha_models:WatershedG4.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u04 .
 
-kanawha:WatershedG9.p01 a rascat:RasPlan ;
+kanawha_models:WatershedG9.p01 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u01 .
+    rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01 .
 
-kanawha:WatershedG9.p02 a rascat:RasPlan ;
+kanawha_models:WatershedG9.p02 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u02 .
+    rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u02 .
 
-kanawha:WatershedG9.p03 a rascat:RasPlan ;
+kanawha_models:WatershedG9.p03 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
-    rascat:hasGeometry kanawha:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u03 .
+    rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u03 .
 
-kanawha:WatershedG9.p04 a rascat:RasPlan ;
+kanawha_models:WatershedG9.p04 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 7.2673e-01 ;
             rascat:pbias 2.8095e+01 ;
             rascat:r2 9.4184e-01 ;
             rascat:rsr 5.2275e-01 ;
             rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u04 .
+    rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u04 .
 
-kanawha:WatershedG9.p05 a rascat:RasPlan ;
+kanawha_models:WatershedG9.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:hydrographType "Flow" ;
             rascat:nse -1.5141e+00 ;
             rascat:pbias 4.5535e+01 ;
             rascat:r2 9.0313e-01 ;
             rascat:rsr 1.5856e+00 ;
             rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:WatershedG9.g02 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u01 .
+    rascat:hasGeometry kanawha_models:WatershedG9.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01 .
 
-kanawha:WatershedG9.p06 a rascat:RasPlan ;
+kanawha_models:WatershedG9.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:hydrographType "Flow" ;
             rascat:nse -5.8891e-02 ;
             rascat:pbias 6.035e+01 ;
             rascat:r2 8.3038e-01 ;
             rascat:rsr 1.029e+00 ;
             rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:WatershedG9.g03 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u02 .
+    rascat:hasGeometry kanawha_models:WatershedG9.g03 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u02 .
 
-kanawha:WatershedG9.p07 a rascat:RasPlan ;
+kanawha_models:WatershedG9.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
             rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:hydrographType "Flow" ;
             rascat:nse 7.2673e-01 ;
             rascat:pbias 2.8095e+01 ;
             rascat:r2 9.4184e-01 ;
             rascat:rsr 5.2275e-01 ;
             rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ] ;
-    rascat:hasGeometry kanawha:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u03 .
+    rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u03 .
 
-kanawha:WatershedG9.p08 a rascat:RasPlan ;
+kanawha_models:WatershedG9.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasGeometry kanawha:WatershedG9.g02 ;
-    rascat:hasUnsteadyFlow kanawha:WatershedG9.u04 .
+    rascat:hasGeometry kanawha_models:WatershedG9.g02 ;
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u04 .
+
+ffrd_orgs:Compass_JV a foaf:Organization ;
+    foaf:name "Compass JV" .
+
+ffrd_people:Andrew_Swynenberg a foaf:Person ;
+    foaf:mbox "Andrew.Swynenberg@freese.com" ;
+    foaf:name "Andrew Swynenberg" .
+
+ffrd_people:Britton_Wells a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "britton.wells@wsp.com" ;
+    foaf:name "Britton Wells" .
+
+ffrd_people:Courtney_Fournier a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "courtney.fournier@aecom.com" ;
+    foaf:name "Courtney Fournier" .
+
+ffrd_people:Dawit_Zeweldi a foaf:Person ;
+    foaf:mbox "Dawit.Zeweldi@freese.com" ;
+    foaf:name "Dawit Zeweldi" .
+
+ffrd_people:Elizabeth_Vande_Krol a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "elizabeth.vandekrol@aecom.com" ;
+    foaf:name "Elizabeth Vande Krol" .
+
+ffrd_people:John_Capobianco a foaf:Person ;
+    foaf:Organization ffrd_orgs:Baker ;
+    foaf:mbox "John.Capobianco@mbakerintl.com" ;
+    foaf:name "John Capobianco" .
+
+ffrd_people:Jon_Bartlotti a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "jonathan.bartlotti@wsp.com" ;
+    foaf:name "Jon Bartlotti" .
+
+ffrd_people:KC_Robinson a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "kc.robinson@aecom.com" ;
+    foaf:name "KC Robinson" .
+
+ffrd_people:Kevan_Lee_Lum a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "kevan.leelum@wsp.com" ;
+    foaf:name "Kevan Lee Lum" .
+
+ffrd_people:Masoud_Meshkat a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "masoud.meshkat@wsp.com" ;
+    foaf:name "Masoud Meshkat" .
+
+ffrd_people:Matt_Lewis a foaf:Person ;
+    foaf:mbox "Matt.Lewis@freese.com" ;
+    foaf:name "Matt Lewis" .
+
+ffrd_people:Michelle_Terry a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "michelle.terry@aecom.com" ;
+    foaf:name "Michelle Terry" .
+
+ffrd_people:Pete_Williams a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "pete.williams@aecom.com" ;
+    foaf:name "Pete Williams" .
+
+ffrd_people:Ryan_Phol a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "ryan.pohl@aecom.com" ;
+    foaf:name "Ryan Phol" .
+
+ffrd_people:Ryan_Pohl a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "ryan.pohl@aecom.com" ;
+    foaf:name "Ryan Pohl" .
+
+ffrd_people:Sirui_Wen a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "sirui.wen@wsp.com" ;
+    foaf:name "Sirui Wen" .
+
+ffrd_people:Yacoub_Raheem a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "yacoub.raheem@aecom.com" ;
+    foaf:name "Yacoub Raheem" .
 
 usgs_gages:03177120 a rascat:Streamgage ;
     dcterms:identifier "03177120" ;
@@ -2581,7 +2716,7 @@ usgs_gages:03196500 a rascat:Streamgage ;
     dcterms:publisher "USGS" ;
     dcterms:title "Birch River at Herold, WV" .
 
-kanawha:BasinG6.g03 a rascat:RasGeometry ;
+kanawha_models:BasinG6.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G6_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -2601,151 +2736,169 @@ kanawha:BasinG6.g03 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:BasinG6.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:BasinG6.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Inital Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:BasinG6.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:BasinG6.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:BasinG6.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:BasinG6.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:BasinG6.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:BasinG6.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:BasinG6.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:BasinG6.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:BasinG6.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:BasinG6.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:BluestoneLocal.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:BluestoneLocal.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1995 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "1995-01-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime ] .
 
-kanawha:BluestoneLocal.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:BluestoneLocal.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "1996-01-30T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] .
 
-kanawha:BluestoneLocal.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:BluestoneLocal.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "2003-11-27T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime ] .
 
-kanawha:BluestoneLocal.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:BluestoneLocal.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "JUN2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Bluestone_Upper.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:Bluestone_Upper.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003_ExessPrecip_Baseflow" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
 
-kanawha:Bluestone_Upper.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:Bluestone_Upper.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1995_ExcessPrecip_Baseflow" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1995 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] .
 
-kanawha:Bluestone_Upper.u08 a rascat:RasUnsteadyFlow ;
+kanawha_models:Bluestone_Upper.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996_ExcessPrecip_Baseflow" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January to February 1996 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] .
 
-kanawha:Bluestone_Upper.u09 a rascat:RasUnsteadyFlow ;
+kanawha_models:Bluestone_Upper.u09 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016_ExcessPrecip_Baseflow" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June to July 2016 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] .
 
-kanawha:CoalRiver.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:CoalRiver.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
 
-kanawha:CoalRiver.u02 a rascat:RasUnsteadyFlow ;
-    dcterms:title "Jan1995a" ;
+kanawha_models:CoalRiver.u02 a rascat:RasUnsteadyFlow ;
+    dcterms:title "Jan1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1995 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ] .
 
-kanawha:CoalRiver.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:CoalRiver.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] .
 
-kanawha:CoalRiver.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:CoalRiver.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:ElkMiddle.g02 a rascat:RasGeometry ;
+kanawha_models:ElkMiddle.g02 a rascat:RasGeometry ;
     dcterms:title "ElkMiddle_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 100 ;
@@ -2764,39 +2917,43 @@ kanawha:ElkMiddle.g02 a rascat:RasGeometry ;
     rascat:hasTerrain [ a rascat:Terrain ;
             rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ] .
 
-kanawha:ElkMiddle.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:ElkMiddle.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Nov2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "2003-11-28T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime ] .
 
-kanawha:ElkMiddle.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:ElkMiddle.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Jan1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1995 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "1995-01-29T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ] .
 
-kanawha:ElkMiddle.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:ElkMiddle.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Jan1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "1996-02-07T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T00:00:00"^^xsd:dateTime ] .
 
-kanawha:ElkMiddle.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:ElkMiddle.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Jun2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ] .
 
-kanawha:G5.g03 a rascat:RasGeometry ;
+kanawha_models:G5.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G5_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -2816,135 +2973,151 @@ kanawha:G5.g03 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:G5.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:G5.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:G5.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:G5.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:G5.u08 a rascat:RasUnsteadyFlow ;
+kanawha_models:G5.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:G5.u09 a rascat:RasUnsteadyFlow ;
+kanawha_models:G5.u09 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:G5.u10 a rascat:RasUnsteadyFlow ;
+kanawha_models:G5.u10 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:G5.u11 a rascat:RasUnsteadyFlow ;
+kanawha_models:G5.u11 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:GSummersville_B.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:GSummersville_B.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Nov2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 applied precipitation, provided by USACE" ;
             rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
 
-kanawha:GSummersville_B.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:GSummersville_B.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jan1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1995 applied precipitation, provided by USACE" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:GSummersville_B.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:GSummersville_B.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jan1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 excess precipitation. USACE-provided HMS excess precip to include snowmelt runoff." ;
             rascat:endDateTime "1996-02-07T10:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] .
 
-kanawha:GSummersville_B.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:GSummersville_B.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jun2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 applied precipitation, provided by USACE" ;
             rascat:endDateTime "2016-07-04T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] .
 
-kanawha:GSummersville_C.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:GSummersville_C.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jun2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 applied precipitation, provided by USACE" ;
             rascat:endDateTime "2016-07-04T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] .
 
-kanawha:GSummersville_C.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:GSummersville_C.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jan1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 excess precipitation. USACE-provided HMS excess precip to include snowmelt runoff." ;
             rascat:endDateTime "1996-02-07T10:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] .
 
-kanawha:GauleyLower_BLE_FEM.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:GauleyLower_BLE_FEM.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleyLower_Floodplain_Nov2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 applied precipitation" ;
             rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime ] .
 
-kanawha:GauleyLower_BLE_FEM.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:GauleyLower_BLE_FEM.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleyLower_Floodplain_Jun2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 applied precipitation" ;
             rascat:endDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ] .
 
-kanawha:GauleyLower_BLE_FEM.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:GauleyLower_BLE_FEM.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleyLower_FloodPlain_Jan1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1995 applied precipitation" ;
             rascat:endDateTime "1995-01-23T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ] .
 
-kanawha:GauleyLower_BLE_FEM.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:GauleyLower_BLE_FEM.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleyLower_FloodPlain_Jan1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 applied precipitation" ;
             rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T00:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G7.g03 a rascat:RasGeometry ;
+kanawha_models:Greenbrier_G7.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G7_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -2964,55 +3137,61 @@ kanawha:Greenbrier_G7.g03 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Greenbrier_G7.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G7.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 IC" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G7.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G7.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003 IC" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G7.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G7.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "JUN2016 Cal" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G7.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G7.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 Cal" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G7.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G7.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996 Cal" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G7.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G7.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003 Cal" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G8.g03 a rascat:RasGeometry ;
+kanawha_models:Greenbrier_G8.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G8_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -3032,119 +3211,133 @@ kanawha:Greenbrier_G8.g03 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Greenbrier_G8.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G8.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 IC" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G8.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G8.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003 IC" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G8.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G8.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "JUN2016 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G8.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G8.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 Cal" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G8.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G8.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996 Cal" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G8.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:Greenbrier_G8.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003 Cal" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G1.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G1.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G1.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G1.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G1.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G1.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G1.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G1.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G1.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G1.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G1.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G1.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G1.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G1.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G1.u08 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G1.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G2.g03 a rascat:RasGeometry ;
+kanawha_models:Kanawha_G2.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G2_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3164,159 +3357,178 @@ kanawha:Kanawha_G2.g03 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Kanawha_G2.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G2.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G2.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G2.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G2.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G2.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G2.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G2.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G2.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G2.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G2.u06 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G2.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G2.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G2.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:Kanawha_G2.u08 a rascat:RasUnsteadyFlow ;
+kanawha_models:Kanawha_G2.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:New-LittleRiver.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:New-LittleRiver.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "JUN2016_HMS" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:New-LittleRiver.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:New-LittleRiver.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996_HMS" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:New-LittleRiver.u08 a rascat:RasUnsteadyFlow ;
+kanawha_models:New-LittleRiver.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003_HMS" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:New-LittleRiver.u09 a rascat:RasUnsteadyFlow ;
+kanawha_models:New-LittleRiver.u09 a rascat:RasUnsteadyFlow ;
     dcterms:title "restart_file" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Small precip event run to fill in some local depressions. Hypothetical flat event for priming the model; total depth roughly equal to 2 yr 4 hr event" ;
             rascat:endDateTime "2003-11-22T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried false ;
             rascat:startDateTime "2003-11-18T00:00:00"^^xsd:dateTime ] .
 
-kanawha:New-LittleRiver.u10 a rascat:RasUnsteadyFlow ;
+kanawha_models:New-LittleRiver.u10 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995_HMS" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1995 gridded excess precipitation, from HEC-HMS in HEC-DSS format" ;
             rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperKanawha.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperKanawha.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "1996-02-04T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-17T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperKanawha.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperKanawha.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996_InitialConditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "January 1996 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "1996-01-17T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperKanawha.u07 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperKanawha.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003_InitialConditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "2003-11-12T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-03T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperKanawha.u08 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperKanawha.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperKanawha.u09 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperKanawha.u09 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016_InitialConditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "2016-06-22T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-07T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperKanawha.u11 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperKanawha.u11 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "June 2016 Corrected AORC Precipitation, provided by USACE" ;
             rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Lower.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Lower.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Restart" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "restart file" ;
@@ -3324,82 +3536,91 @@ kanawha:UpperNew_Lower.u01 a rascat:RasUnsteadyFlow ;
             rascat:spatiallyVaried false ;
             rascat:startDateTime "2000-01-01T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Lower.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Lower.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Lower.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Lower.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)" ;
             rascat:endDateTime "1996-02-02T04:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Lower.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Lower.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)" ;
             rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Lower.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Lower.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)" ;
             rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Upper.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Upper.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)" ;
             rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Upper.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Upper.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)" ;
             rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Upper.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Upper.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)" ;
             rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] .
 
-kanawha:UpperNew_Upper.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:UpperNew_Upper.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Provided by USACE (AORC  gridded precipitation data, normalized with PRISM data)" ;
             rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG3.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG3.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG3.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG3.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 IC" .
 
-kanawha:WatershedG4.g03 a rascat:RasGeometry ;
+kanawha_models:WatershedG4.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3419,7 +3640,7 @@ kanawha:WatershedG4.g03 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:WatershedG9.g03 a rascat:RasGeometry ;
+kanawha_models:WatershedG9.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3438,6 +3659,29 @@ kanawha:WatershedG9.g03 a rascat:RasGeometry ;
             rascat:hasBathymetry [ a rascat:Bathymetry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+
+ffrd_orgs:ARC_JV a foaf:Organization ;
+    foaf:name "ARC JV" .
+
+ffrd_people:Daniyal_Siddiqui a foaf:Person ;
+    foaf:Organization ffrd_orgs:Baker ;
+    foaf:mbox "daniyal.siddiqui@mbakerintl.com" ;
+    foaf:name "Daniyal Siddiqui" .
+
+ffrd_people:Jonathan_Bartlotti a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "jonathan.bartlotti@wsp.com" ;
+    foaf:name "Jonathan Bartlotti" .
+
+ffrd_people:Julianna_Villa a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "julianna.villa@wsp.com" ;
+    foaf:name "Julianna Villa" .
+
+ffrd_people:Reuben_Cozmyer a foaf:Person ;
+    foaf:Organization ffrd_orgs:AECOM ;
+    foaf:mbox "reuben.cozmyer@aecom.com" ;
+    foaf:name "Reuben Cozmyer" .
 
 usgs_gages:03165500 a rascat:Streamgage ;
     dcterms:identifier "03165500" ;
@@ -3458,39 +3702,43 @@ usgs_gages:03198350 a rascat:Streamgage ;
     dcterms:description "Structures pulled from existing 1D HEC-RAS models where available." ;
     dcterms:title "WV State GIS Data Clearinghouse - HEC-RAS Models" .
 
-kanawha:BasinG6.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:BasinG6.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:G5.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:G5.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:GSummersville_C.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:GSummersville_C.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Nov2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "November 2003 applied precipitation, provided by USACE" ;
             rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
 
-kanawha:GSummersville_C.u05 a rascat:RasUnsteadyFlow ;
+kanawha_models:GSummersville_C.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jan1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
-            dcterms:description "January 1996 excess precipitation. USACE-provided HMS excess precip to include snowmelt runoff." ;
-            rascat:endDateTime "1996-02-07T10:00:00"^^xsd:dateTime ;
+            dcterms:description "January 1995 applied precipitation, provided by USACE" ;
+            rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T13:00:00"^^xsd:dateTime ] .
 
-kanawha:Greenbrier_G7.g01 a rascat:RasGeometry ;
+kanawha_models:Greenbrier_G7.g01 a rascat:RasGeometry ;
     dcterms:title "Greenbrier_G7_LiDAR" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -3513,7 +3761,7 @@ kanawha:Greenbrier_G7.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Greenbrier_G8.g01 a rascat:RasGeometry ;
+kanawha_models:Greenbrier_G8.g01 a rascat:RasGeometry ;
     dcterms:title "Greenbrier_G8_LiDAR" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -3536,7 +3784,7 @@ kanawha:Greenbrier_G8.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Kanawha_G1.g02 a rascat:RasGeometry ;
+kanawha_models:Kanawha_G1.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3559,7 +3807,7 @@ kanawha:Kanawha_G1.g02 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Kanawha_G1.g03 a rascat:RasGeometry ;
+kanawha_models:Kanawha_G1.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3579,7 +3827,7 @@ kanawha:Kanawha_G1.g03 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Kanawha_G2.g02 a rascat:RasGeometry ;
+kanawha_models:Kanawha_G2.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G2_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3602,7 +3850,7 @@ kanawha:Kanawha_G2.g02 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:WatershedG3.g03 a rascat:RasGeometry ;
+kanawha_models:WatershedG3.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_1996" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3622,31 +3870,34 @@ kanawha:WatershedG3.g03 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:WatershedG3.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG3.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG3.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG3.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG3.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG3.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG4.g02 a rascat:RasGeometry ;
+kanawha_models:WatershedG4.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3669,39 +3920,43 @@ kanawha:WatershedG4.g02 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:WatershedG4.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG4.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG4.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG4.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG4.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG4.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG4.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG4.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG9.g02 a rascat:RasGeometry ;
+kanawha_models:WatershedG9.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3724,37 +3979,56 @@ kanawha:WatershedG9.g02 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:WatershedG9.u01 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG9.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1995 event" ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG9.u02 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG9.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the January 1996 event" ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG9.u03 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG9.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the November 2003 event" ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
 
-kanawha:WatershedG9.u04 a rascat:RasUnsteadyFlow ;
+kanawha_models:WatershedG9.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016" ;
     rascat:hasHyetograph [ a rascat:Hyetograph ;
             dcterms:description "Gridded precipitation data from the June 2016 event" ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
+            rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+
+ffrd_orgs:Baker a foaf:Organization ;
+    foaf:Organization ffrd_orgs:ARC_JV ;
+    foaf:homepage <https://mbakerintl.com/> ;
+    foaf:name "Michael Baker Intl" .
+
+ffrd_people:Dami_George a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "dami.george@wsp.com" ;
+    foaf:name "Dami George" .
+
+ffrd_people:Mark_McBroom a foaf:Person ;
+    foaf:Organization ffrd_orgs:Baker ;
+    foaf:mbox "mmcbroom@mbakerintl.com" ;
+    foaf:name "Mark McBroom" .
 
 usgs_gages:03177710 a rascat:Streamgage ;
     dcterms:identifier "03177710" ;
@@ -3766,7 +4040,7 @@ usgs_gages:03191500 a rascat:Streamgage ;
     dcterms:publisher "USGS" ;
     dcterms:title "Peters Creek Near Lockwood, WV" .
 
-kanawha:BasinG6.g02 a rascat:RasGeometry ;
+kanawha_models:BasinG6.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G6_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3789,7 +4063,7 @@ kanawha:BasinG6.g02 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:ElkMiddle.g01 a rascat:RasGeometry ;
+kanawha_models:ElkMiddle.g01 a rascat:RasGeometry ;
     dcterms:title "ElkMiddle" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 100 ;
@@ -3811,7 +4085,7 @@ kanawha:ElkMiddle.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from existing CWMS 1D HEC-RAS model. Channel raster developed and mosaiced to DEM and then incorporated into model" ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments. Hydroflattened major rivers" ] ] .
 
-kanawha:G5.g02 a rascat:RasGeometry ;
+kanawha_models:G5.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G5_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3834,7 +4108,7 @@ kanawha:G5.g02 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Greenbrier_G7.g02 a rascat:RasGeometry ;
+kanawha_models:Greenbrier_G7.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G7_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -3857,7 +4131,7 @@ kanawha:Greenbrier_G7.g02 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:Greenbrier_G8.g02 a rascat:RasGeometry ;
+kanawha_models:Greenbrier_G8.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G8_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -3880,7 +4154,7 @@ kanawha:Greenbrier_G8.g02 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:WatershedG3.g01 a rascat:RasGeometry ;
+kanawha_models:WatershedG3.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3903,7 +4177,7 @@ kanawha:WatershedG3.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:WatershedG3.g02 a rascat:RasGeometry ;
+kanawha_models:WatershedG3.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -3996,7 +4270,7 @@ usgs_gages:03200500 a rascat:Streamgage ;
     dcterms:publisher "USGS" ;
     dcterms:title "Coal River at Tornado, WV" .
 
-kanawha:BasinG6.g01 a rascat:RasGeometry ;
+kanawha_models:BasinG6.g01 a rascat:RasGeometry ;
     dcterms:title "GreenbrierBasinG6_LiDAR" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -4019,7 +4293,7 @@ kanawha:BasinG6.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:BluestoneLocal.g01 a rascat:RasGeometry ;
+kanawha_models:BluestoneLocal.g01 a rascat:RasGeometry ;
     dcterms:title "BL-1" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 100 ;
@@ -4037,7 +4311,7 @@ kanawha:BluestoneLocal.g01 a rascat:RasGeometry ;
             rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ] ] .
 
-kanawha:Bluestone_Upper.g07 a rascat:RasGeometry ;
+kanawha_models:Bluestone_Upper.g07 a rascat:RasGeometry ;
     dcterms:title "400ft_Refined_100ft_NoSCS" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 400 ;
@@ -4055,7 +4329,7 @@ kanawha:Bluestone_Upper.g07 a rascat:RasGeometry ;
             rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and dam/berm embankments. LiDAR-processed DEM was hydroflattened by provider." ] ] .
 
-kanawha:CoalRiver.g01 a rascat:RasGeometry ;
+kanawha_models:CoalRiver.g01 a rascat:RasGeometry ;
     dcterms:description "Nominal rectangular cell spacing of 500' x 500', refined along stream corridors and other breaklines areas to be approximately 100' cells. No losses (e.g. SCS CN) modeled directly in HEC-RAS." ;
     dcterms:title "CoalRiver" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
@@ -4073,7 +4347,7 @@ kanawha:CoalRiver.g01 a rascat:RasGeometry ;
     rascat:hasTerrain [ a rascat:Terrain ;
             rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ] .
 
-kanawha:G5.g01 a rascat:RasGeometry ;
+kanawha_models:G5.g01 a rascat:RasGeometry ;
     dcterms:title "GreenbrierBasinG5_LiDAR" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -4096,7 +4370,7 @@ kanawha:G5.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:GSummersville_B.g01 a rascat:RasGeometry ;
+kanawha_models:GSummersville_B.g01 a rascat:RasGeometry ;
     dcterms:title "GauleySummersville_Existing" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -4117,7 +4391,7 @@ kanawha:GSummersville_B.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] ] .
 
-kanawha:GauleyLower_BLE_FEM.g01 a rascat:RasGeometry ;
+kanawha_models:GauleyLower_BLE_FEM.g01 a rascat:RasGeometry ;
     dcterms:title "Gauley_Lower" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -4140,7 +4414,7 @@ kanawha:GauleyLower_BLE_FEM.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] ] .
 
-kanawha:Kanawha_G1.g01 a rascat:RasGeometry ;
+kanawha_models:Kanawha_G1.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -4163,7 +4437,7 @@ kanawha:Kanawha_G1.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:UpperNew_Upper.g01 a rascat:RasGeometry ;
+kanawha_models:UpperNew_Upper.g01 a rascat:RasGeometry ;
     dcterms:title "UpperNew_Upper_geom" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 100 ;
@@ -4185,7 +4459,7 @@ usgs_gages:03196800 a rascat:Streamgage ;
     dcterms:publisher "USGS" ;
     dcterms:title "Elk River at Clay, WV" .
 
-kanawha:Kanawha_G2.g01 a rascat:RasGeometry ;
+kanawha_models:Kanawha_G2.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G2" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -4208,7 +4482,7 @@ kanawha:Kanawha_G2.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:New-LittleRiver.g01 a rascat:RasGeometry ;
+kanawha_models:New-LittleRiver.g01 a rascat:RasGeometry ;
     dcterms:title "New_Little_River" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 100 ;
@@ -4224,7 +4498,7 @@ kanawha:New-LittleRiver.g01 a rascat:RasGeometry ;
             rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ] ] .
 
-kanawha:UpperNew_Lower.g03 a rascat:RasGeometry ;
+kanawha_models:UpperNew_Lower.g03 a rascat:RasGeometry ;
     dcterms:title "Simplified" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -4243,7 +4517,7 @@ kanawha:UpperNew_Lower.g03 a rascat:RasGeometry ;
     rascat:hasTerrain [ a rascat:Terrain ;
             rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ] .
 
-kanawha:WatershedG4.g01 a rascat:RasGeometry ;
+kanawha_models:WatershedG4.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -4266,7 +4540,7 @@ kanawha:WatershedG4.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:WatershedG9.g01 a rascat:RasGeometry ;
+kanawha_models:WatershedG9.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 50 ;
@@ -4289,7 +4563,7 @@ kanawha:WatershedG9.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
 
-kanawha:GSummersville_C.g01 a rascat:RasGeometry ;
+kanawha_models:GSummersville_C.g01 a rascat:RasGeometry ;
     dcterms:title "GauleySummersville_Existing" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -4312,7 +4586,7 @@ kanawha:GSummersville_C.g01 a rascat:RasGeometry ;
                     dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ] ;
             rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] ] .
 
-kanawha:UpperKanawha.g01 a rascat:RasGeometry ;
+kanawha_models:UpperKanawha.g01 a rascat:RasGeometry ;
     dcterms:title "UpperKanawha" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
             rascat:breaklinesMaxCellSize 200 ;
@@ -4351,6 +4625,26 @@ usgs_gages:03192000 a rascat:Streamgage ;
     dcterms:publisher "USGS" ;
     dcterms:title "Gauley River Above Belva, WV" .
 
+ffrd_orgs:AECOM a foaf:Organization ;
+    foaf:Organization ffrd_orgs:Compass_JV ;
+    foaf:homepage <https://www.aecom.com/> ;
+    foaf:name "AECOM" .
+
+ffrd_people:Ben_Rufenacht a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "ben.rufenacht@wsp.com" ;
+    foaf:name "Ben Rufenacht" .
+
+ffrd_people:Josh_Hill a foaf:Person ;
+    foaf:Organization ffrd_orgs:WSP ;
+    foaf:mbox "josh.hill@wsp.com" ;
+    foaf:name "Josh Hill" .
+
+ffrd_orgs:WSP a foaf:Organization ;
+    foaf:Organization ffrd_orgs:ARC_JV ;
+    foaf:homepage <https://www.wsp.com/> ;
+    foaf:name "WSP, Inc." .
+
 usgs_gages:03189100 a rascat:Streamgage ;
     dcterms:identifier "03189100" ;
     dcterms:publisher "USGS" ;
@@ -4362,10 +4656,10 @@ usgs_gages:03187500 a rascat:Streamgage ;
     dcterms:title "Cranberry River Near Richwood, WV" .
 
 <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> a rascat:LanduseLandcover ;
-    dcterms:description "National Land Cover Database 2019 (CONUS);" ;
+    dcterms:description "National Land Cover Database 2019 (CONUS)" ;
     dcterms:title "NLCD 2019" .
 
-kanawha:mmc_albers_ft.prj a rascat:Projection ;
+kanawha_models:mmc_albers_ft.prj a rascat:Projection ;
     dcterms:description "Modified version of ESRI:102309, provided by USACE. Units are in feet, whereas EPSG:102309 is in meters." ;
     dcterms:title "Albers Equal Area Conic (feet)" .
 
@@ -4376,4 +4670,24 @@ kanawha:mmc_albers_ft.prj a rascat:Projection ;
 <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> a rascat:DEM ;
     dcterms:description "Digital Elevation Model for the Kanawha River Basin, based on USGS 3DEP data." ;
     dcterms:title "Kanawha River Basin DEM" .
+
+kanawha_events:Jan1996 a rascat:HydroEvent ;
+    dcterms:title "January 1996" ;
+    rascat:endDateTime "1995-02-01T00:00:00"^^xsd:dateTime ;
+    rascat:startDateTime "1995-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_events:Jan1995 a rascat:HydroEvent ;
+    dcterms:title "January 1995" ;
+    rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
+    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime .
+
+kanawha_events:Nov2003 a rascat:HydroEvent ;
+    dcterms:title "November 2003" ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime .
+
+kanawha_events:Jun2016 a rascat:HydroEvent ;
+    dcterms:title "June 2016" ;
+    rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
 

--- a/kanawha.ttl
+++ b/kanawha.ttl
@@ -2,7 +2,9 @@
 @prefix ffrd_orgs: <http://example.ffrd.fema.gov/orgs/> .
 @prefix ffrd_people: <http://example.ffrd.fema.gov/people/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix kanawha_calibration: <http://example.ffrd.fema.gov/kanawha/calibration/> .
 @prefix kanawha_events: <http://example.ffrd.fema.gov/kanawha/events/> .
+@prefix kanawha_misc: <http://example.ffrd.fema.gov/kanawha/misc/> .
 @prefix kanawha_models: <http://example.ffrd.fema.gov/kanawha/models/> .
 @prefix rascat: <http://www.example.org/rascat/0.1#> .
 @prefix usgs_gages: <https://waterdata.usgs.gov/monitoring-location/> .
@@ -510,10 +512,1641 @@ kanawha_models:WatershedG9.prj a rascat:RasModel ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-<https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> a rascat:Streamgage ;
-    dcterms:identifier "USACE_Summersville_Lake" ;
-    dcterms:publisher "USACE" ;
-    dcterms:title "Summersville Lake" .
+kanawha_calibration:BasinG6_03182888_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2023-03-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03182888 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 6.4704e-01 ;
+    rascat:pbias -1.1989e-01 ;
+    rascat:r2 9.0879e-01 ;
+    rascat:rsr 5.9411e-01 ;
+    rascat:startDateTime "2007-10-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03177120 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 2.9e-01 ;
+    rascat:pbias 2.0672e+01 ;
+    rascat:r2 2.9e-01 ;
+    rascat:rsr 1.14e+00 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03179800 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.43e-01 ;
+    rascat:pbias 2.53e-01 ;
+    rascat:r2 9.46e-01 ;
+    rascat:rsr 2.53e-01 ;
+    rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-01-30T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03179800 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.8e-01 ;
+    rascat:pbias -1.896e+00 ;
+    rascat:r2 8.8e-01 ;
+    rascat:rsr 3.6e-01 ;
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03179800 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 4e-02 ;
+    rascat:pbias 3.555e+01 ;
+    rascat:r2 1e-02 ;
+    rascat:rsr 1.11e+00 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-27T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03179800 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.5e-01 ;
+    rascat:pbias 6.839e+00 ;
+    rascat:r2 9.5e-01 ;
+    rascat:rsr 2.3e-01 ;
+    rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03177710 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 5.6e-01 ;
+    rascat:r2 6.2e-01 ;
+    rascat:rsr 6.6e-01 ;
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03177710 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.9e-01 ;
+    rascat:pbias 1.316e+01 ;
+    rascat:r2 9.1e-01 ;
+    rascat:rsr 3.3e-01 ;
+    rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03177710 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -2e-01 ;
+    rascat:pbias 1.484e+01 ;
+    rascat:r2 1e-02 ;
+    rascat:rsr 1.09e+00 ;
+    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03179000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.4e-01 ;
+    rascat:r2 8.8e-01 ;
+    rascat:rsr 3.9e-01 ;
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03179000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.2e-01 ;
+    rascat:pbias 1.383e+01 ;
+    rascat:r2 8.8e-01 ;
+    rascat:rsr 4.2e-01 ;
+    rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03179000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 3e-02 ;
+    rascat:pbias 3.429e+01 ;
+    rascat:r2 2.8e-01 ;
+    rascat:rsr 9.9e-01 ;
+    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03179000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.3e-01 ;
+    rascat:r2 9.4e-01 ;
+    rascat:rsr 2.7e-01 ;
+    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03198350_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03198350 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 5.7e-01 ;
+    rascat:pbias 2.513e+01 ;
+    rascat:r2 7.3e-01 ;
+    rascat:rsr 6.5e-01 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03198350_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03198350 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.9e-01 ;
+    rascat:pbias 4.51e+00 ;
+    rascat:r2 9e-01 ;
+    rascat:rsr 3.2e-01 ;
+    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03198500_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03198500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 4e-02 ;
+    rascat:pbias 3.598e+01 ;
+    rascat:r2 2.3e-01 ;
+    rascat:rsr 9.5e-01 ;
+    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03198500_Flow_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03198500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse -1.97e+00 ;
+    rascat:pbias -3.224e+01 ;
+    rascat:r2 8e-02 ;
+    rascat:rsr 1.67e+00 ;
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03198500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03198500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 3.6e-01 ;
+    rascat:pbias 3.169e+01 ;
+    rascat:r2 5e-01 ;
+    rascat:rsr 8e-01 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03198500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03198500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.5e-01 ;
+    rascat:pbias 1.206e+01 ;
+    rascat:r2 8.6e-01 ;
+    rascat:rsr 3.9e-01 ;
+    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03200500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 2.5e-01 ;
+    rascat:pbias 2.036e+01 ;
+    rascat:r2 3.2e-01 ;
+    rascat:rsr 8.4e-01 ;
+    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03200500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 7.2e-01 ;
+    rascat:pbias 8.02e+00 ;
+    rascat:r2 7.3e-01 ;
+    rascat:rsr 5.1e-01 ;
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03200500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 7e-02 ;
+    rascat:pbias 3.821e+01 ;
+    rascat:r2 2.7e-01 ;
+    rascat:rsr 9.6e-01 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03200500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.7e-01 ;
+    rascat:pbias 1.417e+01 ;
+    rascat:r2 8.9e-01 ;
+    rascat:rsr 3.6e-01 ;
+    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03196500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 2.9614e-01 ;
+    rascat:pbias -6.8283e-02 ;
+    rascat:r2 5.6463e-01 ;
+    rascat:rsr 8.3896e-01 ;
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03196600 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -8.3698e-01 ;
+    rascat:pbias -1.1895e-01 ;
+    rascat:r2 6.511e-01 ;
+    rascat:rsr 1.3554e+00 ;
+    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03196600 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 3.7745e-01 ;
+    rascat:pbias 1.821e-01 ;
+    rascat:r2 6.5615e-01 ;
+    rascat:rsr 7.8902e-01 ;
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196600_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03196600 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -2.0927e-01 ;
+    rascat:pbias -2.8261e-01 ;
+    rascat:r2 7.4283e-01 ;
+    rascat:rsr 1.0997e+00 ;
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03196600 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 3.1117e-01 ;
+    rascat:pbias -1.6572e-01 ;
+    rascat:r2 7.701e-01 ;
+    rascat:rsr 8.2996e-01 ;
+    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196800_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03196800 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 6.1359e-01 ;
+    rascat:pbias -2.8881e+01 ;
+    rascat:r2 9.1515e-01 ;
+    rascat:rsr 6.2162e-01 ;
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196800_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03196800 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -1.504e-01 ;
+    rascat:pbias -2.2115e-01 ;
+    rascat:r2 6.714e-01 ;
+    rascat:rsr 1.0726e+00 ;
+    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03196800 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 2.812e-01 ;
+    rascat:pbias 3.5148e-01 ;
+    rascat:r2 6.1136e-01 ;
+    rascat:rsr 8.4782e-01 ;
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196800_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03196800 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 6.0684e-01 ;
+    rascat:pbias -3.9992e-01 ;
+    rascat:r2 8.5544e-01 ;
+    rascat:rsr 6.2702e-01 ;
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03196800_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03196800 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.6802e-01 ;
+    rascat:pbias -1.3772e-01 ;
+    rascat:r2 9.3277e-01 ;
+    rascat:rsr 3.6328e-01 ;
+    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03197000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 4.3444e-01 ;
+    rascat:pbias 7.7577e+00 ;
+    rascat:r2 6.2639e-01 ;
+    rascat:rsr 7.5204e-01 ;
+    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03197000_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03197000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.3616e-01 ;
+    rascat:pbias -1.8492e+00 ;
+    rascat:r2 9.3743e-01 ;
+    rascat:rsr 2.5266e-01 ;
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03197000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.0487e-01 ;
+    rascat:pbias 1.3164e+01 ;
+    rascat:r2 9.2731e-01 ;
+    rascat:rsr 3.0843e-01 ;
+    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03197000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -1.3776e+00 ;
+    rascat:pbias 2.1848e-01 ;
+    rascat:r2 6.5966e-01 ;
+    rascat:rsr 1.5419e+00 ;
+    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03197000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -1.1679e+00 ;
+    rascat:pbias 7.8082e-01 ;
+    rascat:r2 6.1415e-01 ;
+    rascat:rsr 1.4724e+00 ;
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03197000_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03197000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 7.7057e-01 ;
+    rascat:pbias 1.2879e-01 ;
+    rascat:r2 8.1636e-01 ;
+    rascat:rsr 4.7899e-01 ;
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03197000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 7.3831e-01 ;
+    rascat:pbias 2.4529e-01 ;
+    rascat:r2 9.0156e-01 ;
+    rascat:rsr 5.1156e-01 ;
+    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03186500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.6e-01 ;
+    rascat:pbias -4.63e+00 ;
+    rascat:r2 9.6e-01 ;
+    rascat:rsr 1.9e-01 ;
+    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03186500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.6e-01 ;
+    rascat:pbias 2.608e+01 ;
+    rascat:r2 9.6e-01 ;
+    rascat:rsr 3.7e-01 ;
+    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03187000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -3.8e-01 ;
+    rascat:pbias -8e-02 ;
+    rascat:r2 7.6e-01 ;
+    rascat:rsr 1.18e+00 ;
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03187000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -7.7e-01 ;
+    rascat:pbias -1.7e-01 ;
+    rascat:r2 6e-01 ;
+    rascat:rsr 1.33e+00 ;
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187000_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03187000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 7.5e-01 ;
+    rascat:pbias -8e-02 ;
+    rascat:r2 8.3e-01 ;
+    rascat:rsr 5e-01 ;
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187000_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03187000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 4.3e-01 ;
+    rascat:pbias -1.3e-01 ;
+    rascat:r2 9.1e-01 ;
+    rascat:rsr 7.5e-01 ;
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 7.2e-01 ;
+    rascat:pbias 1.2e+00 ;
+    rascat:r2 8.7e-01 ;
+    rascat:rsr 5.3e-01 ;
+    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.5e-01 ;
+    rascat:pbias 3.176e+01 ;
+    rascat:r2 9.8e-01 ;
+    rascat:rsr 2.2e-01 ;
+    rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187500_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -3.13e+00 ;
+    rascat:pbias -7e-02 ;
+    rascat:r2 8.9e-01 ;
+    rascat:rsr 2.03e+00 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187500_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -3.91e+00 ;
+    rascat:pbias -1.2e-01 ;
+    rascat:r2 7e-01 ;
+    rascat:rsr 2.22e+00 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187500_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -1.33e+00 ;
+    rascat:pbias -1e-01 ;
+    rascat:r2 8.4e-01 ;
+    rascat:rsr 1.53e+00 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03187500_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -4.1e-01 ;
+    rascat:pbias -7e-02 ;
+    rascat:r2 9.1e-01 ;
+    rascat:rsr 1.19e+00 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03188900_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03188900 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.1e-01 ;
+    rascat:pbias 1.609e+01 ;
+    rascat:r2 9.2e-01 ;
+    rascat:rsr 3e-01 ;
+    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03189100_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.6e-01 ;
+    rascat:pbias -5.06e+00 ;
+    rascat:r2 9.6e-01 ;
+    rascat:rsr 2e-01 ;
+    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03189100_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.8e-01 ;
+    rascat:pbias 2.228e+01 ;
+    rascat:r2 9e-01 ;
+    rascat:rsr 3.5e-01 ;
+    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.8e-01 ;
+    rascat:pbias 3e-02 ;
+    rascat:r2 9.8e-01 ;
+    rascat:rsr 3.4e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 6e-01 ;
+    rascat:pbias -2e-01 ;
+    rascat:r2 7.4e-01 ;
+    rascat:rsr 6.4e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03189100_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.1e-01 ;
+    rascat:pbias -1e-02 ;
+    rascat:r2 9.1e-01 ;
+    rascat:rsr 3.1e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_03189100_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 7.7e-01 ;
+    rascat:pbias 5e-02 ;
+    rascat:r2 8.7e-01 ;
+    rascat:rsr 4.8e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -2e-01 ;
+    rascat:pbias -2.7e-01 ;
+    rascat:r2 9.8e-01 ;
+    rascat:rsr 1.05e+00 ;
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -5e-02 ;
+    rascat:pbias 1.29e+00 ;
+    rascat:r2 6.6e-01 ;
+    rascat:rsr 1.02e+00 ;
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.8e-01 ;
+    rascat:pbias -1.1e-01 ;
+    rascat:r2 9.3e-01 ;
+    rascat:rsr 3.4e-01 ;
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 5.74e-01 ;
+    rascat:pbias 1.181e+00 ;
+    rascat:r2 6.07e-01 ;
+    rascat:rsr 6.53e-01 ;
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03186500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.4e-01 ;
+    rascat:pbias 1.403e+01 ;
+    rascat:r2 9.4e-01 ;
+    rascat:rsr 2.5e-01 ;
+    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03186500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.8e-01 ;
+    rascat:pbias 3.256e+01 ;
+    rascat:r2 9.5e-01 ;
+    rascat:rsr 3.5e-01 ;
+    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03187000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -1e-02 ;
+    rascat:pbias 6e-02 ;
+    rascat:r2 5.7e-01 ;
+    rascat:rsr 1e+00 ;
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03187000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 4.9e-01 ;
+    rascat:pbias -6e-02 ;
+    rascat:r2 6.6e-01 ;
+    rascat:rsr 7.1e-01 ;
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187000_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03187000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 7e-01 ;
+    rascat:pbias 5e-02 ;
+    rascat:r2 7.4e-01 ;
+    rascat:rsr 5.4e-01 ;
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187000_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03187000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.2e-01 ;
+    rascat:pbias 1e-02 ;
+    rascat:r2 9.2e-01 ;
+    rascat:rsr 2.9e-01 ;
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 7.2e-01 ;
+    rascat:pbias 1.755e+01 ;
+    rascat:r2 8.2e-01 ;
+    rascat:rsr 5.2e-01 ;
+    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8e-01 ;
+    rascat:pbias 5.039e+01 ;
+    rascat:r2 8.8e-01 ;
+    rascat:rsr 4.5e-01 ;
+    rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187500_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -3e-02 ;
+    rascat:pbias -3e-02 ;
+    rascat:r2 7.3e-01 ;
+    rascat:rsr 1.01e+00 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187500_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -1.53e+00 ;
+    rascat:pbias -8e-02 ;
+    rascat:r2 7e-01 ;
+    rascat:rsr 1.59e+00 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187500_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 1e-02 ;
+    rascat:pbias -6e-02 ;
+    rascat:r2 7.7e-01 ;
+    rascat:rsr 1e+00 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03187500_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03187500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 6.6e-01 ;
+    rascat:pbias -2e-02 ;
+    rascat:r2 8.9e-01 ;
+    rascat:rsr 5.9e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03188900_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03188900 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.8e-01 ;
+    rascat:pbias 1.599e+01 ;
+    rascat:r2 8.9e-01 ;
+    rascat:rsr 3.4e-01 ;
+    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03189100_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.2e-01 ;
+    rascat:pbias 1.849e+01 ;
+    rascat:r2 9.3e-01 ;
+    rascat:rsr 2.9e-01 ;
+    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03189100_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.1e-01 ;
+    rascat:pbias 4.14e+01 ;
+    rascat:r2 8.8e-01 ;
+    rascat:rsr 4.4e-01 ;
+    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 4.9e-01 ;
+    rascat:pbias 3e-02 ;
+    rascat:r2 7.7e-01 ;
+    rascat:rsr 7.1e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 5.5e-01 ;
+    rascat:pbias -4e-02 ;
+    rascat:r2 7.3e-01 ;
+    rascat:rsr 6.7e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03189100_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.4e-01 ;
+    rascat:pbias 1e-02 ;
+    rascat:r2 8.6e-01 ;
+    rascat:rsr 4.1e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_03189100_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03189100 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 7.2e-01 ;
+    rascat:pbias 5e-02 ;
+    rascat:r2 8.6e-01 ;
+    rascat:rsr 5.3e-01 ;
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -2.46e+00 ;
+    rascat:pbias 4.1e-01 ;
+    rascat:r2 8.2e-01 ;
+    rascat:rsr 1.86e+00 ;
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -2.1e-01 ;
+    rascat:pbias 1.4e+00 ;
+    rascat:r2 6.4e-01 ;
+    rascat:rsr 1.1e+00 ;
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.7e-01 ;
+    rascat:pbias 2.8e-01 ;
+    rascat:r2 9.9e-01 ;
+    rascat:rsr 3.5e-01 ;
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.8e-01 ;
+    rascat:pbias 3e-02 ;
+    rascat:r2 9e-01 ;
+    rascat:rsr 3.5e-01 ;
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03190000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.59e-01 ;
+    rascat:pbias -1.1652e+01 ;
+    rascat:r2 8.78e-01 ;
+    rascat:rsr 3.76e-01 ;
+    rascat:startDateTime "2012-08-30T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03190000_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03190000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.12e-01 ;
+    rascat:pbias -7.4e-02 ;
+    rascat:r2 9.53e-01 ;
+    rascat:rsr 2.959e-01 ;
+    rascat:startDateTime "2014-04-02T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03191500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 6.67e-01 ;
+    rascat:pbias 1.26e+01 ;
+    rascat:r2 6.7e-01 ;
+    rascat:rsr 5.77e-01 ;
+    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03191500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 5.74e-01 ;
+    rascat:pbias 1.181e+00 ;
+    rascat:r2 6.07e-01 ;
+    rascat:rsr 6.53e-01 ;
+    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03191500_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03191500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 6.91e-01 ;
+    rascat:pbias 3.1e-02 ;
+    rascat:r2 8.96e-01 ;
+    rascat:rsr 5.56e-01 ;
+    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03192000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.52e-01 ;
+    rascat:pbias -1.5726e+00 ;
+    rascat:r2 9.62e-01 ;
+    rascat:rsr 2.18e-01 ;
+    rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03192000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 6.49e-01 ;
+    rascat:pbias 2.4806e+01 ;
+    rascat:r2 7.85e-01 ;
+    rascat:rsr 5.93e-01 ;
+    rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-31T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03192000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.13e-01 ;
+    rascat:pbias 1.5e+00 ;
+    rascat:r2 9.18e-01 ;
+    rascat:rsr 2.95e-01 ;
+    rascat:startDateTime "2016-04-30T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-12-31T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03192000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 5.93e-01 ;
+    rascat:pbias 1.6551e+01 ;
+    rascat:r2 6.66e-01 ;
+    rascat:rsr 6.38e-01 ;
+    rascat:startDateTime "2003-09-30T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03192000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 4.88e-01 ;
+    rascat:pbias -1.95e-01 ;
+    rascat:r2 9.59e-01 ;
+    rascat:rsr 7.15e-01 ;
+    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03192000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.28e-01 ;
+    rascat:pbias -9.6e-02 ;
+    rascat:r2 8.75e-01 ;
+    rascat:rsr 4.15e-01 ;
+    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03192000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 7.82e-01 ;
+    rascat:pbias -2.01e-01 ;
+    rascat:r2 8.76e-01 ;
+    rascat:rsr 4.67e-01 ;
+    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-09-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03192000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 6.25e-01 ;
+    rascat:pbias -1.82e-01 ;
+    rascat:r2 7.84e-01 ;
+    rascat:rsr 6.12e-01 ;
+    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03183500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -1.8586e+00 ;
+    rascat:pbias 4.089e+01 ;
+    rascat:r2 4.2492e-01 ;
+    rascat:rsr 1.6907e+00 ;
+    rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03183500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -9.5796e-01 ;
+    rascat:pbias 5.867e+01 ;
+    rascat:r2 5.4692e-01 ;
+    rascat:rsr 1.3993e+00 ;
+    rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03183500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.6125e-01 ;
+    rascat:pbias 2.2797e+01 ;
+    rascat:r2 9.0781e-01 ;
+    rascat:rsr 3.7249e-01 ;
+    rascat:startDateTime "2016-04-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-12-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03183500 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 7.5762e-01 ;
+    rascat:pbias 3.0033e+01 ;
+    rascat:r2 9.363e-01 ;
+    rascat:rsr 4.9232e-01 ;
+    rascat:startDateTime "2003-09-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03180500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse -1.7704e-01 ;
+    rascat:pbias 3.2361e+01 ;
+    rascat:r2 8.9384e-01 ;
+    rascat:rsr 1.0849e+00 ;
+    rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03180500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 4.3346e-01 ;
+    rascat:pbias 2.2303e+01 ;
+    rascat:r2 9.242e-01 ;
+    rascat:rsr 7.5269e-01 ;
+    rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03180500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 4.5906e-01 ;
+    rascat:pbias 2.6618e+01 ;
+    rascat:r2 7.3227e-01 ;
+    rascat:rsr 7.3549e-01 ;
+    rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03180500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 3.1295e-01 ;
+    rascat:pbias 3.1036e+01 ;
+    rascat:r2 8.1655e-01 ;
+    rascat:rsr 8.2889e-01 ;
+    rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03170000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.5e-01 ;
+    rascat:pbias -5.96e+00 ;
+    rascat:r2 9.6e-01 ;
+    rascat:rsr 2.2e-01 ;
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+
+kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03170000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9e-01 ;
+    rascat:pbias -2.86e+00 ;
+    rascat:r2 9.5e-01 ;
+    rascat:rsr 3.2e-01 ;
+    rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03170000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 3.5e-01 ;
+    rascat:pbias 1.411e+01 ;
+    rascat:r2 6.4e-01 ;
+    rascat:rsr 8.1e-01 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03170000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.4e-01 ;
+    rascat:pbias 5.13e+00 ;
+    rascat:r2 9.4e-01 ;
+    rascat:rsr 2.5e-01 ;
+    rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03171000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 5.7e-01 ;
+    rascat:pbias 9.25e+00 ;
+    rascat:r2 5.8e-01 ;
+    rascat:rsr 6.5e-01 ;
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+
+kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03171000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 5.6e-01 ;
+    rascat:pbias 1.31e+00 ;
+    rascat:r2 5.6e-01 ;
+    rascat:rsr 6.6e-01 ;
+    rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03171000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -3.1e-01 ;
+    rascat:pbias 1.955e+01 ;
+    rascat:r2 1e-02 ;
+    rascat:rsr 1.14e+00 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03171000 ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 3.8e-01 ;
+    rascat:pbias 9.42e+00 ;
+    rascat:r2 3.9e-01 ;
+    rascat:rsr 7.9e-01 ;
+    rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016 a rascat:Hydrograph ;
+    dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
+    dcterms:title "London L&D Pool" ;
+    rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#London%20L&D%20Pool> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -1.807e+02 ;
+    rascat:pbias -2.696e-01 ;
+    rascat:r2 7.9179e-03 ;
+    rascat:rsr 1.348e+01 ;
+    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003 a rascat:Hydrograph ;
+    dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
+    dcterms:title "London L&D Pool" ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#London%20L&D%20Pool> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse -5.0493e+01 ;
+    rascat:pbias -1.8653e-01 ;
+    rascat:r2 2.2156e-01 ;
+    rascat:rsr 7.1759e+00 ;
+    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Jun2016 a rascat:Hydrograph ;
+    dcterms:description "Stage hydrograph provided by USACE." ;
+    dcterms:title "London L&D Tailwater" ;
+    rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#London%20L&D%20Tailwater> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.6292e-01 ;
+    rascat:pbias -1.3638e-01 ;
+    rascat:r2 9.8229e-01 ;
+    rascat:rsr 1.9255e-01 ;
+    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Nov2003 a rascat:Hydrograph ;
+    dcterms:description "Stage hydrograph provided by USACE." ;
+    dcterms:title "London L&D Tailwater" ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#London%20L&D%20Tailwater> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.4446e-01 ;
+    rascat:pbias -1.4871e-01 ;
+    rascat:r2 9.8069e-01 ;
+    rascat:rsr 2.3567e-01 ;
+    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016 a rascat:Hydrograph ;
+    dcterms:description "Stage hydrograph provided by USACE." ;
+    dcterms:title "Marmet L&D Pool" ;
+    rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#Marmet%20L&D%20Pool> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 4.3975e-01 ;
+    rascat:pbias 7.278e-02 ;
+    rascat:r2 5.7783e-01 ;
+    rascat:rsr 7.485e-01 ;
+    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003 a rascat:Hydrograph ;
+    dcterms:description "Stage hydrograph provided by USACE." ;
+    dcterms:title "Marmet L&D Pool" ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#Marmet%20L&D%20Pool> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.3132e-01 ;
+    rascat:pbias 2.3509e-02 ;
+    rascat:r2 9.2922e-01 ;
+    rascat:rsr 4.1071e-01 ;
+    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 a rascat:Hydrograph ;
+    dcterms:description "Stage hydrograph provided by USACE." ;
+    dcterms:title "Marmet L&D Tailwater" ;
+    rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#Marmet%20L&D%20Tailwater> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 9.2097e-01 ;
+    rascat:pbias 1.2004e-01 ;
+    rascat:r2 9.2979e-01 ;
+    rascat:rsr 2.8112e-01 ;
+    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 a rascat:Hydrograph ;
+    dcterms:description "Stage hydrograph provided by USACE." ;
+    dcterms:title "Marmet L&D Tailwater" ;
+    rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#Marmet%20L&D%20Tailwater> ;
+    rascat:hydrographType "Stage" ;
+    rascat:nse 8.0228e-01 ;
+    rascat:pbias 6.1883e-02 ;
+    rascat:r2 8.096e-01 ;
+    rascat:rsr 4.4465e-01 ;
+    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03165500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 5.6e-01 ;
+    rascat:pbias 4.2e-01 ;
+    rascat:r2 7.23e-01 ;
+    rascat:rsr 7.23e-01 ;
+    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03165500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.79e-01 ;
+    rascat:pbias 7.498e+00 ;
+    rascat:r2 9.35e-01 ;
+    rascat:rsr 4.8e-01 ;
+    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03168000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.24e-01 ;
+    rascat:pbias 3.959e+00 ;
+    rascat:r2 9.78e-01 ;
+    rascat:rsr 2.76e-01 ;
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-02-02T04:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03168000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 3.03e-01 ;
+    rascat:pbias 9.689e+00 ;
+    rascat:r2 3.26e-01 ;
+    rascat:rsr 8.34e-01 ;
+    rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03168000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse -3.43e-01 ;
+    rascat:pbias 5.316e+00 ;
+    rascat:r2 4.9e-02 ;
+    rascat:rsr 1.302e+00 ;
+    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03168000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 6.92e-01 ;
+    rascat:pbias 2.6041e+01 ;
+    rascat:r2 9.84e-01 ;
+    rascat:rsr 5.55e-01 ;
+    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03161000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.6e-01 ;
+    rascat:pbias -5.26e+00 ;
+    rascat:r2 9.7e-01 ;
+    rascat:rsr 2.1e-01 ;
+    rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03161000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 7.6e-01 ;
+    rascat:pbias -2.61e+00 ;
+    rascat:r2 7.9e-01 ;
+    rascat:rsr 4.8e-01 ;
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03161000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse -1.22e+00 ;
+    rascat:pbias -8.08e+00 ;
+    rascat:r2 2e-02 ;
+    rascat:rsr 1.49e+00 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03161000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.7e-01 ;
+    rascat:pbias -7.82e+00 ;
+    rascat:r2 9.7e-01 ;
+    rascat:rsr 1.8e-01 ;
+    rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03164000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 8.8e-01 ;
+    rascat:pbias 2.077e+01 ;
+    rascat:r2 9.1e-01 ;
+    rascat:rsr 3.4e-01 ;
+    rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03164000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse -3.4e-01 ;
+    rascat:pbias 5.675e+01 ;
+    rascat:r2 3.3e-01 ;
+    rascat:rsr 1.16e+00 ;
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03164000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse -7.27e+00 ;
+    rascat:pbias 5.876e+01 ;
+    rascat:r2 1.4e-01 ;
+    rascat:rsr 2.87e+00 ;
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+
+kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03164000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 6.2e-01 ;
+    rascat:pbias 4.4e+01 ;
+    rascat:r2 8e-01 ;
+    rascat:rsr 6.2e-01 ;
+    rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 a rascat:Hydrograph ;
+    dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1995" ;
+    rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03182500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 1.3088e-01 ;
+    rascat:pbias 3.516e+01 ;
+    rascat:r2 6.1693e-01 ;
+    rascat:rsr 9.3227e-01 ;
+    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 a rascat:Hydrograph ;
+    dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1996" ;
+    rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03182500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 5.2781e-01 ;
+    rascat:pbias 3.5098e+01 ;
+    rascat:r2 9.1635e-01 ;
+    rascat:rsr 6.8716e-01 ;
+    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 a rascat:Hydrograph ;
+    dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in June 2016" ;
+    rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03182500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 9.627e-01 ;
+    rascat:pbias 1.3292e+01 ;
+    rascat:r2 9.8257e-01 ;
+    rascat:rsr 1.9314e-01 ;
+    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 a rascat:Hydrograph ;
+    dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in November 2003" ;
+    rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03182500 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 6.3691e-01 ;
+    rascat:pbias 4.5403e+01 ;
+    rascat:r2 9.099e-01 ;
+    rascat:rsr 6.0257e-01 ;
+    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1995 ;
+    rascat:fromStreamgage usgs_gages:03184000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse -1.5141e+00 ;
+    rascat:pbias 4.5535e+01 ;
+    rascat:r2 9.0313e-01 ;
+    rascat:rsr 1.5856e+00 ;
+    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jan1996 ;
+    rascat:fromStreamgage usgs_gages:03184000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse -5.8891e-02 ;
+    rascat:pbias 6.035e+01 ;
+    rascat:r2 8.3038e-01 ;
+    rascat:rsr 1.029e+00 ;
+    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Jun2016 ;
+    rascat:fromStreamgage usgs_gages:03184000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 7.2673e-01 ;
+    rascat:pbias 2.8095e+01 ;
+    rascat:r2 9.4184e-01 ;
+    rascat:rsr 5.2275e-01 ;
+    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
+
+kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 a rascat:Hydrograph ;
+    rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
+    rascat:fromHydroEvent kanawha_events:Nov2003 ;
+    rascat:fromStreamgage usgs_gages:03184000 ;
+    rascat:hydrographType "Flow" ;
+    rascat:nse 7.2673e-01 ;
+    rascat:pbias 2.8095e+01 ;
+    rascat:r2 9.4184e-01 ;
+    rascat:rsr 5.2275e-01 ;
+    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
+
+kanawha_models:BasinG6.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:BasinG6.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:BasinG6.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:BasinG6.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:BasinG6.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:BasinG6.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:BasinG6.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:BasinG6.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:BasinG6.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
 
 kanawha_models:BasinG6.p01 a rascat:RasPlan ;
     dcterms:description "Plan was not utilized" ;
@@ -554,88 +2187,42 @@ kanawha_models:BasinG6.p07 a rascat:RasPlan ;
 
 kanawha_models:BasinG6.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2023-03-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03182888 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 6.4704e-01 ;
-            rascat:pbias -1.1989e-01 ;
-            rascat:r2 9.0879e-01 ;
-            rascat:rsr 5.9411e-01 ;
-            rascat:startDateTime "2007-10-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:BasinG6_03182888_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:BasinG6.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:BasinG6.u06 .
 
+kanawha_models:BluestoneLocal.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ] .
+
 kanawha_models:BluestoneLocal.p01 a rascat:RasPlan ;
     dcterms:title "JAN1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03179800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.43e-01 ;
-            rascat:pbias 2.53e-01 ;
-            rascat:r2 9.46e-01 ;
-            rascat:rsr 2.53e-01 ;
-            rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u01 .
 
 kanawha_models:BluestoneLocal.p02 a rascat:RasPlan ;
     dcterms:title "JAN1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-01-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03179800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias -1.896e+00 ;
-            rascat:r2 8.8e-01 ;
-            rascat:rsr 3.6e-01 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u02 .
 
 kanawha_models:BluestoneLocal.p03 a rascat:RasPlan ;
     dcterms:title "NOV2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-27T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03179800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.5e-01 ;
-            rascat:pbias 6.839e+00 ;
-            rascat:r2 9.5e-01 ;
-            rascat:rsr 2.3e-01 ;
-            rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u03 .
 
 kanawha_models:BluestoneLocal.p04 a rascat:RasPlan ;
     dcterms:title "JUN2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03177120 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 2.9e-01 ;
-            rascat:pbias 2.0672e+01 ;
-            rascat:r2 2.9e-01 ;
-            rascat:rsr 1.14e+00 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03179800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 4e-02 ;
-            rascat:pbias 3.555e+01 ;
-            rascat:r2 1e-02 ;
-            rascat:rsr 1.11e+00 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016,
+        kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u04 .
+
+kanawha_models:Bluestone_Upper.g07.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and dam/berm embankments. LiDAR-processed DEM was hydroflattened by provider." ] .
 
 kanawha_models:Bluestone_Upper.p15 a rascat:RasPlan ;
     dcterms:description """Jan 5-29, 1995 (UTC) using excess precip from Corps HMS model plus baseflow
@@ -643,24 +2230,8 @@ kanawha_models:Bluestone_Upper.p15 a rascat:RasPlan ;
 Some  Breaklines and Terrain mods
 """ ;
     dcterms:title "Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03179000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.4e-01 ;
-            rascat:r2 8.8e-01 ;
-            rascat:rsr 3.9e-01 ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03177710 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 5.6e-01 ;
-            rascat:r2 6.2e-01 ;
-            rascat:rsr 6.6e-01 ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995,
+        kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
     rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u07 .
 
@@ -670,26 +2241,8 @@ kanawha_models:Bluestone_Upper.p16 a rascat:RasPlan ;
 Somebreaklines and terrain mods
 """ ;
     dcterms:title "Jan1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03179000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.2e-01 ;
-            rascat:pbias 1.383e+01 ;
-            rascat:r2 8.8e-01 ;
-            rascat:rsr 4.2e-01 ;
-            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03177710 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.9e-01 ;
-            rascat:pbias 1.316e+01 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 3.3e-01 ;
-            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996,
+        kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
     rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u08 .
 
@@ -699,26 +2252,8 @@ kanawha_models:Bluestone_Upper.p17 a rascat:RasPlan ;
 100 ft stream refinement regions, 50 ft ref reg in towns
 Some Breaklines and terrain mods""" ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03179000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 3e-02 ;
-            rascat:pbias 3.429e+01 ;
-            rascat:r2 2.8e-01 ;
-            rascat:rsr 9.9e-01 ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03177710 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2e-01 ;
-            rascat:pbias 1.484e+01 ;
-            rascat:r2 1e-02 ;
-            rascat:rsr 1.09e+00 ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016,
+        kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
     rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u09 .
 
@@ -728,328 +2263,115 @@ kanawha_models:Bluestone_Upper.p18 a rascat:RasPlan ;
 100ft stream refinement , 50ft ref  in towns
 Some breaklines and culvert terrain mods""" ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03179000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.3e-01 ;
-            rascat:r2 9.4e-01 ;
-            rascat:rsr 2.7e-01 ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
     rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u06 .
 
+kanawha_models:CoalRiver.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> .
+
 kanawha_models:CoalRiver.p01 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03198350 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.9e-01 ;
-            rascat:pbias 4.51e+00 ;
-            rascat:r2 9e-01 ;
-            rascat:rsr 3.2e-01 ;
-            rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03200500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.7e-01 ;
-            rascat:pbias 1.417e+01 ;
-            rascat:r2 8.9e-01 ;
-            rascat:rsr 3.6e-01 ;
-            rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03198500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.5e-01 ;
-            rascat:pbias 1.206e+01 ;
-            rascat:r2 8.6e-01 ;
-            rascat:rsr 3.9e-01 ;
-            rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:CoalRiver_03198350_Flow_Nov2003,
+        kanawha_calibration:CoalRiver_03198500_Flow_Nov2003,
+        kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u01 .
 
 kanawha_models:CoalRiver.p02 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03198500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 4e-02 ;
-            rascat:pbias 3.598e+01 ;
-            rascat:r2 2.3e-01 ;
-            rascat:rsr 9.5e-01 ;
-            rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03200500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 2.5e-01 ;
-            rascat:pbias 2.036e+01 ;
-            rascat:r2 3.2e-01 ;
-            rascat:rsr 8.4e-01 ;
-            rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:CoalRiver_03198500_Flow_Jan1995,
+        kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u02 .
 
 kanawha_models:CoalRiver.p03 a rascat:RasPlan ;
     dcterms:title "Jan1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03200500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.2e-01 ;
-            rascat:pbias 8.02e+00 ;
-            rascat:r2 7.3e-01 ;
-            rascat:rsr 5.1e-01 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03198500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -1.97e+00 ;
-            rascat:pbias -3.224e+01 ;
-            rascat:r2 8e-02 ;
-            rascat:rsr 1.67e+00 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:CoalRiver_03198500_Flow_Jan1996,
+        kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u03 .
 
 kanawha_models:CoalRiver.p04 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03200500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7e-02 ;
-            rascat:pbias 3.821e+01 ;
-            rascat:r2 2.7e-01 ;
-            rascat:rsr 9.6e-01 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03198350 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 5.7e-01 ;
-            rascat:pbias 2.513e+01 ;
-            rascat:r2 7.3e-01 ;
-            rascat:rsr 6.5e-01 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03198500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 3.6e-01 ;
-            rascat:pbias 3.169e+01 ;
-            rascat:r2 5e-01 ;
-            rascat:rsr 8e-01 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:CoalRiver_03198350_Flow_Jun2016,
+        kanawha_calibration:CoalRiver_03198500_Flow_Jun2016,
+        kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u04 .
+
+kanawha_models:ElkMiddle.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from existing CWMS 1D HEC-RAS model. Channel raster developed and mosaiced to DEM and then incorporated into model" .
+
+kanawha_models:ElkMiddle.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:ElkMiddle.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments. Hydroflattened major rivers" ] .
+
+kanawha_models:ElkMiddle.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> .
 
 kanawha_models:ElkMiddle.p01 a rascat:RasPlan ;
     dcterms:description "November 2003.Calibrated to Queen Shoals Gage" ;
     dcterms:title "Unsteady_Mixed_Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.3831e-01 ;
-            rascat:pbias 2.4529e-01 ;
-            rascat:r2 9.0156e-01 ;
-            rascat:rsr 5.1156e-01 ;
-            rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03196600 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 3.1117e-01 ;
-            rascat:pbias -1.6572e-01 ;
-            rascat:r2 7.701e-01 ;
-            rascat:rsr 8.2996e-01 ;
-            rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.0487e-01 ;
-            rascat:pbias 1.3164e+01 ;
-            rascat:r2 9.2731e-01 ;
-            rascat:rsr 3.0843e-01 ;
-            rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03196800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.6802e-01 ;
-            rascat:pbias -1.3772e-01 ;
-            rascat:r2 9.3277e-01 ;
-            rascat:rsr 3.6328e-01 ;
-            rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003,
+        kanawha_calibration:ElkMiddle_03196800_Stage_Nov2003,
+        kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003,
+        kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u02 .
 
 kanawha_models:ElkMiddle.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jan1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03196800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 2.812e-01 ;
-            rascat:pbias 3.5148e-01 ;
-            rascat:r2 6.1136e-01 ;
-            rascat:rsr 8.4782e-01 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03196600 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 3.7745e-01 ;
-            rascat:pbias 1.821e-01 ;
-            rascat:r2 6.5615e-01 ;
-            rascat:rsr 7.8902e-01 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1.1679e+00 ;
-            rascat:pbias 7.8082e-01 ;
-            rascat:r2 6.1415e-01 ;
-            rascat:rsr 1.4724e+00 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996,
+        kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996,
+        kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u05 .
 
 kanawha_models:ElkMiddle.p04 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.3616e-01 ;
-            rascat:pbias -1.8492e+00 ;
-            rascat:r2 9.3743e-01 ;
-            rascat:rsr 2.5266e-01 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.7057e-01 ;
-            rascat:pbias 1.2879e-01 ;
-            rascat:r2 8.1636e-01 ;
-            rascat:rsr 4.7899e-01 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03196600 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2.0927e-01 ;
-            rascat:pbias -2.8261e-01 ;
-            rascat:r2 7.4283e-01 ;
-            rascat:rsr 1.0997e+00 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03196800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 6.0684e-01 ;
-            rascat:pbias -3.9992e-01 ;
-            rascat:r2 8.5544e-01 ;
-            rascat:rsr 6.2702e-01 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03196500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 2.9614e-01 ;
-            rascat:pbias -6.8283e-02 ;
-            rascat:r2 5.6463e-01 ;
-            rascat:rsr 8.3896e-01 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03196800 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.1359e-01 ;
-            rascat:pbias -2.8881e+01 ;
-            rascat:r2 9.1515e-01 ;
-            rascat:rsr 6.2162e-01 ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016,
+        kanawha_calibration:ElkMiddle_03196600_Stage_Jun2016,
+        kanawha_calibration:ElkMiddle_03196800_Flow_Jun2016,
+        kanawha_calibration:ElkMiddle_03196800_Stage_Jun2016,
+        kanawha_calibration:ElkMiddle_03197000_Flow_Jun2016,
+        kanawha_calibration:ElkMiddle_03197000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u06 .
 
 kanawha_models:ElkMiddle.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03196600 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -8.3698e-01 ;
-            rascat:pbias -1.1895e-01 ;
-            rascat:r2 6.511e-01 ;
-            rascat:rsr 1.3554e+00 ;
-            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 4.3444e-01 ;
-            rascat:pbias 7.7577e+00 ;
-            rascat:r2 6.2639e-01 ;
-            rascat:rsr 7.5204e-01 ;
-            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03197000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1.3776e+00 ;
-            rascat:pbias 2.1848e-01 ;
-            rascat:r2 6.5966e-01 ;
-            rascat:rsr 1.5419e+00 ;
-            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03196800 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1.504e-01 ;
-            rascat:pbias -2.2115e-01 ;
-            rascat:r2 6.714e-01 ;
-            rascat:rsr 1.0726e+00 ;
-            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995,
+        kanawha_calibration:ElkMiddle_03196800_Stage_Jan1995,
+        kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995,
+        kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u04 .
+
+kanawha_models:G5.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:G5.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:G5.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:G5.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:G5.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:G5.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:G5.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:G5.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:G5.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
 
 kanawha_models:G5.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
@@ -1096,403 +2418,87 @@ kanawha_models:G5.p14 a rascat:RasPlan ;
 kanawha_models:G5.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Initial Conditions" .
 
+kanawha_models:GSummersville_B.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." .
+
+kanawha_models:GSummersville_B.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:GSummersville_B.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] .
+
 kanawha_models:GSummersville_B.p01 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -5e-02 ;
-            rascat:pbias 1.29e+00 ;
-            rascat:r2 6.6e-01 ;
-            rascat:rsr 1.02e+00 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -3.91e+00 ;
-            rascat:pbias -1.2e-01 ;
-            rascat:r2 7e-01 ;
-            rascat:rsr 2.22e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -7.7e-01 ;
-            rascat:pbias -1.7e-01 ;
-            rascat:r2 6e-01 ;
-            rascat:rsr 1.33e+00 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 6e-01 ;
-            rascat:pbias -2e-01 ;
-            rascat:r2 7.4e-01 ;
-            rascat:rsr 6.4e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996,
+        kanawha_calibration:GSummersville_B_03187500_Stage_Jan1996,
+        kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996,
+        kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u05 .
 
 kanawha_models:GSummersville_B.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -4.1e-01 ;
-            rascat:pbias -7e-02 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 1.19e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03186500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.6e-01 ;
-            rascat:pbias 2.608e+01 ;
-            rascat:r2 9.6e-01 ;
-            rascat:rsr 3.7e-01 ;
-            rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 4.3e-01 ;
-            rascat:pbias -1.3e-01 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 7.5e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.5e-01 ;
-            rascat:pbias 3.176e+01 ;
-            rascat:r2 9.8e-01 ;
-            rascat:rsr 2.2e-01 ;
-            rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias 2.228e+01 ;
-            rascat:r2 9e-01 ;
-            rascat:rsr 3.5e-01 ;
-            rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.7e-01 ;
-            rascat:pbias 5e-02 ;
-            rascat:r2 8.7e-01 ;
-            rascat:rsr 4.8e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 5.74e-01 ;
-            rascat:pbias 1.181e+00 ;
-            rascat:r2 6.07e-01 ;
-            rascat:rsr 6.53e-01 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003,
+        kanawha_calibration:GSummersville_B_03187000_Stage_Nov2003,
+        kanawha_calibration:GSummersville_B_03187500_Flow_Nov2003,
+        kanawha_calibration:GSummersville_B_03187500_Stage_Nov2003,
+        kanawha_calibration:GSummersville_B_03189100_Flow_Nov2003,
+        kanawha_calibration:GSummersville_B_03189100_Stage_Nov2003,
+        kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u01 .
 
 kanawha_models:GSummersville_B.p11 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.6e-01 ;
-            rascat:pbias -5.06e+00 ;
-            rascat:r2 9.6e-01 ;
-            rascat:rsr 2e-01 ;
-            rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.1e-01 ;
-            rascat:pbias -1e-02 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 3.1e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.1e-01 ;
-            rascat:pbias 1.609e+01 ;
-            rascat:r2 9.2e-01 ;
-            rascat:rsr 3e-01 ;
-            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.5e-01 ;
-            rascat:pbias -8e-02 ;
-            rascat:r2 8.3e-01 ;
-            rascat:rsr 5e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03186500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.6e-01 ;
-            rascat:pbias -4.63e+00 ;
-            rascat:r2 9.6e-01 ;
-            rascat:rsr 1.9e-01 ;
-            rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias -1.1e-01 ;
-            rascat:r2 9.3e-01 ;
-            rascat:rsr 3.4e-01 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.2e-01 ;
-            rascat:pbias 1.2e+00 ;
-            rascat:r2 8.7e-01 ;
-            rascat:rsr 5.3e-01 ;
-            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1.33e+00 ;
-            rascat:pbias -1e-01 ;
-            rascat:r2 8.4e-01 ;
-            rascat:rsr 1.53e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016,
+        kanawha_calibration:GSummersville_B_03187000_Stage_Jun2016,
+        kanawha_calibration:GSummersville_B_03187500_Flow_Jun2016,
+        kanawha_calibration:GSummersville_B_03187500_Stage_Jun2016,
+        kanawha_calibration:GSummersville_B_03188900_Flow_Jun2016,
+        kanawha_calibration:GSummersville_B_03189100_Flow_Jun2016,
+        kanawha_calibration:GSummersville_B_03189100_Stage_Jun2016,
+        kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u07 .
 
 kanawha_models:GSummersville_B.p12 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2e-01 ;
-            rascat:pbias -2.7e-01 ;
-            rascat:r2 9.8e-01 ;
-            rascat:rsr 1.05e+00 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -3.8e-01 ;
-            rascat:pbias -8e-02 ;
-            rascat:r2 7.6e-01 ;
-            rascat:rsr 1.18e+00 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -3.13e+00 ;
-            rascat:pbias -7e-02 ;
-            rascat:r2 8.9e-01 ;
-            rascat:rsr 2.03e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias 3e-02 ;
-            rascat:r2 9.8e-01 ;
-            rascat:rsr 3.4e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995,
+        kanawha_calibration:GSummersville_B_03187500_Stage_Jan1995,
+        kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995,
+        kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u03 .
 
+kanawha_models:GSummersville_C.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." .
+
+kanawha_models:GSummersville_C.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:GSummersville_C.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] .
+
 kanawha_models:GSummersville_C.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.1e-01 ;
-            rascat:pbias 4.14e+01 ;
-            rascat:r2 8.8e-01 ;
-            rascat:rsr 4.4e-01 ;
-            rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.2e-01 ;
-            rascat:pbias 1e-02 ;
-            rascat:r2 9.2e-01 ;
-            rascat:rsr 2.9e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03186500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias 3.256e+01 ;
-            rascat:r2 9.5e-01 ;
-            rascat:rsr 3.5e-01 ;
-            rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8e-01 ;
-            rascat:pbias 5.039e+01 ;
-            rascat:r2 8.8e-01 ;
-            rascat:rsr 4.5e-01 ;
-            rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias 3e-02 ;
-            rascat:r2 9e-01 ;
-            rascat:rsr 3.5e-01 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 6.6e-01 ;
-            rascat:pbias -2e-02 ;
-            rascat:r2 8.9e-01 ;
-            rascat:rsr 5.9e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.2e-01 ;
-            rascat:pbias 5e-02 ;
-            rascat:r2 8.6e-01 ;
-            rascat:rsr 5.3e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003,
+        kanawha_calibration:GSummersville_C_03187000_Stage_Nov2003,
+        kanawha_calibration:GSummersville_C_03187500_Flow_Nov2003,
+        kanawha_calibration:GSummersville_C_03187500_Stage_Nov2003,
+        kanawha_calibration:GSummersville_C_03189100_Flow_Nov2003,
+        kanawha_calibration:GSummersville_C_03189100_Stage_Nov2003,
+        kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u03 .
 
 kanawha_models:GSummersville_C.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias 1.599e+01 ;
-            rascat:r2 8.9e-01 ;
-            rascat:rsr 3.4e-01 ;
-            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 1e-02 ;
-            rascat:pbias -6e-02 ;
-            rascat:r2 7.7e-01 ;
-            rascat:rsr 1e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03186500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.4e-01 ;
-            rascat:pbias 1.403e+01 ;
-            rascat:r2 9.4e-01 ;
-            rascat:rsr 2.5e-01 ;
-            rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.7e-01 ;
-            rascat:pbias 2.8e-01 ;
-            rascat:r2 9.9e-01 ;
-            rascat:rsr 3.5e-01 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.4e-01 ;
-            rascat:pbias 1e-02 ;
-            rascat:r2 8.6e-01 ;
-            rascat:rsr 4.1e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.2e-01 ;
-            rascat:pbias 1.755e+01 ;
-            rascat:r2 8.2e-01 ;
-            rascat:rsr 5.2e-01 ;
-            rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7e-01 ;
-            rascat:pbias 5e-02 ;
-            rascat:r2 7.4e-01 ;
-            rascat:rsr 5.4e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.2e-01 ;
-            rascat:pbias 1.849e+01 ;
-            rascat:r2 9.3e-01 ;
-            rascat:rsr 2.9e-01 ;
-            rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016,
+        kanawha_calibration:GSummersville_C_03187000_Stage_Jun2016,
+        kanawha_calibration:GSummersville_C_03187500_Flow_Jun2016,
+        kanawha_calibration:GSummersville_C_03187500_Stage_Jun2016,
+        kanawha_calibration:GSummersville_C_03188900_Flow_Jun2016,
+        kanawha_calibration:GSummersville_C_03189100_Flow_Jun2016,
+        kanawha_calibration:GSummersville_C_03189100_Stage_Jun2016,
+        kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u04 .
 
@@ -1503,45 +2509,10 @@ kanawha_models:GSummersville_C.p04 a rascat:RasPlan ;
 
 kanawha_models:GSummersville_C.p05 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1e-02 ;
-            rascat:pbias 6e-02 ;
-            rascat:r2 5.7e-01 ;
-            rascat:rsr 1e+00 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2.46e+00 ;
-            rascat:pbias 4.1e-01 ;
-            rascat:r2 8.2e-01 ;
-            rascat:rsr 1.86e+00 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -3e-02 ;
-            rascat:pbias -3e-02 ;
-            rascat:r2 7.3e-01 ;
-            rascat:rsr 1.01e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 4.9e-01 ;
-            rascat:pbias 3e-02 ;
-            rascat:r2 7.7e-01 ;
-            rascat:rsr 7.1e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995,
+        kanawha_calibration:GSummersville_C_03187500_Stage_Jan1995,
+        kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995,
+        kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u05 .
 
@@ -1552,197 +2523,77 @@ kanawha_models:GSummersville_C.p06 a rascat:RasPlan ;
 
 kanawha_models:GSummersville_C.p07 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -2.1e-01 ;
-            rascat:pbias 1.4e+00 ;
-            rascat:r2 6.4e-01 ;
-            rascat:rsr 1.1e+00 ;
-            rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03187500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1.53e+00 ;
-            rascat:pbias -8e-02 ;
-            rascat:r2 7e-01 ;
-            rascat:rsr 1.59e+00 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03189100 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 5.5e-01 ;
-            rascat:pbias -4e-02 ;
-            rascat:r2 7.3e-01 ;
-            rascat:rsr 6.7e-01 ;
-            rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03187000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 4.9e-01 ;
-            rascat:pbias -6e-02 ;
-            rascat:r2 6.6e-01 ;
-            rascat:rsr 7.1e-01 ;
-            rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996,
+        kanawha_calibration:GSummersville_C_03187500_Stage_Jan1996,
+        kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996,
+        kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u06 .
 
+kanawha_models:GauleyLower_BLE_FEM.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." .
+
+kanawha_models:GauleyLower_BLE_FEM.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:GauleyLower_BLE_FEM.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] .
+
 kanawha_models:GauleyLower_BLE_FEM.p01 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-31T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 5.93e-01 ;
-            rascat:pbias 1.6551e+01 ;
-            rascat:r2 6.66e-01 ;
-            rascat:rsr 6.38e-01 ;
-            rascat:startDateTime "2003-09-30T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-09-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 6.25e-01 ;
-            rascat:pbias -1.82e-01 ;
-            rascat:r2 7.84e-01 ;
-            rascat:rsr 6.12e-01 ;
-            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03191500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 5.74e-01 ;
-            rascat:pbias 1.181e+00 ;
-            rascat:r2 6.07e-01 ;
-            rascat:rsr 6.53e-01 ;
-            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003,
+        kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003,
+        kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u01 .
 
 kanawha_models:GauleyLower_BLE_FEM.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 4.88e-01 ;
-            rascat:pbias -1.95e-01 ;
-            rascat:r2 9.59e-01 ;
-            rascat:rsr 7.15e-01 ;
-            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.52e-01 ;
-            rascat:pbias -1.5726e+00 ;
-            rascat:r2 9.62e-01 ;
-            rascat:rsr 2.18e-01 ;
-            rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995,
+        kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u03 .
 
 kanawha_models:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-31T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.13e-01 ;
-            rascat:pbias 1.5e+00 ;
-            rascat:r2 9.18e-01 ;
-            rascat:rsr 2.95e-01 ;
-            rascat:startDateTime "2016-04-30T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.82e-01 ;
-            rascat:pbias -2.01e-01 ;
-            rascat:r2 8.76e-01 ;
-            rascat:rsr 4.67e-01 ;
-            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03191500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.67e-01 ;
-            rascat:pbias 1.26e+01 ;
-            rascat:r2 6.7e-01 ;
-            rascat:rsr 5.77e-01 ;
-            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03190000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.12e-01 ;
-            rascat:pbias -7.4e-02 ;
-            rascat:r2 9.53e-01 ;
-            rascat:rsr 2.959e-01 ;
-            rascat:startDateTime "2014-04-02T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03191500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 6.91e-01 ;
-            rascat:pbias 3.1e-02 ;
-            rascat:r2 8.96e-01 ;
-            rascat:rsr 5.56e-01 ;
-            rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03190000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.59e-01 ;
-            rascat:pbias -1.1652e+01 ;
-            rascat:r2 8.78e-01 ;
-            rascat:rsr 3.76e-01 ;
-            rascat:startDateTime "2012-08-30T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016,
+        kanawha_calibration:GauleyLower_BLE_FEM_03190000_Stage_Jun2016,
+        kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Jun2016,
+        kanawha_calibration:GauleyLower_BLE_FEM_03191500_Stage_Jun2016,
+        kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jun2016,
+        kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u02 .
 
 kanawha_models:GauleyLower_BLE_FEM.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.28e-01 ;
-            rascat:pbias -9.6e-02 ;
-            rascat:r2 8.75e-01 ;
-            rascat:rsr 4.15e-01 ;
-            rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03192000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.49e-01 ;
-            rascat:pbias 2.4806e+01 ;
-            rascat:r2 7.85e-01 ;
-            rascat:rsr 5.93e-01 ;
-            rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996,
+        kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u04 .
+
+kanawha_models:Greenbrier_G7.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Greenbrier_G7.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Greenbrier_G7.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:Greenbrier_G7.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Greenbrier_G7.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Greenbrier_G7.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:Greenbrier_G7.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Greenbrier_G7.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Greenbrier_G7.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
 
 kanawha_models:Greenbrier_G7.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
@@ -1774,6 +2625,30 @@ kanawha_models:Greenbrier_G7.p07 a rascat:RasPlan ;
     rascat:hasGeometry kanawha_models:Greenbrier_G7.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u07 .
 
+kanawha_models:Greenbrier_G8.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Greenbrier_G8.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Greenbrier_G8.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:Greenbrier_G8.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Greenbrier_G8.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Greenbrier_G8.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:Greenbrier_G8.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Greenbrier_G8.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Greenbrier_G8.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
 kanawha_models:Greenbrier_G8.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
@@ -1786,66 +2661,54 @@ kanawha_models:Greenbrier_G8.p03 a rascat:RasPlan ;
 
 kanawha_models:Greenbrier_G8.p04 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03183500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.6125e-01 ;
-            rascat:pbias 2.2797e+01 ;
-            rascat:r2 9.0781e-01 ;
-            rascat:rsr 3.7249e-01 ;
-            rascat:startDateTime "2016-04-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u04 .
 
 kanawha_models:Greenbrier_G8.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03183500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1.8586e+00 ;
-            rascat:pbias 4.089e+01 ;
-            rascat:r2 4.2492e-01 ;
-            rascat:rsr 1.6907e+00 ;
-            rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u05 .
 
 kanawha_models:Greenbrier_G8.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03183500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -9.5796e-01 ;
-            rascat:pbias 5.867e+01 ;
-            rascat:r2 5.4692e-01 ;
-            rascat:rsr 1.3993e+00 ;
-            rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u06 .
 
 kanawha_models:Greenbrier_G8.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-12-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03183500 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 7.5762e-01 ;
-            rascat:pbias 3.0033e+01 ;
-            rascat:r2 9.363e-01 ;
-            rascat:rsr 4.9232e-01 ;
-            rascat:startDateTime "2003-09-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u07 .
 
 kanawha_models:Greenbrier_G8.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996" .
+
+kanawha_models:Kanawha_G1.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Kanawha_G1.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Kanawha_G1.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:Kanawha_G1.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Kanawha_G1.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Kanawha_G1.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:Kanawha_G1.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Kanawha_G1.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Kanawha_G1.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
 
 kanawha_models:Kanawha_G1.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
@@ -1873,63 +2736,51 @@ kanawha_models:Kanawha_G1.p04 a rascat:RasPlan ;
 
 kanawha_models:Kanawha_G1.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03180500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -1.7704e-01 ;
-            rascat:pbias 3.2361e+01 ;
-            rascat:r2 8.9384e-01 ;
-            rascat:rsr 1.0849e+00 ;
-            rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u05 .
 
 kanawha_models:Kanawha_G1.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03180500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 4.3346e-01 ;
-            rascat:pbias 2.2303e+01 ;
-            rascat:r2 9.242e-01 ;
-            rascat:rsr 7.5269e-01 ;
-            rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u06 .
 
 kanawha_models:Kanawha_G1.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03180500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 3.1295e-01 ;
-            rascat:pbias 3.1036e+01 ;
-            rascat:r2 8.1655e-01 ;
-            rascat:rsr 8.2889e-01 ;
-            rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u07 .
 
 kanawha_models:Kanawha_G1.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03180500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 4.5906e-01 ;
-            rascat:pbias 2.6618e+01 ;
-            rascat:r2 7.3227e-01 ;
-            rascat:rsr 7.3549e-01 ;
-            rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u08 .
+
+kanawha_models:Kanawha_G2.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Kanawha_G2.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Kanawha_G2.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:Kanawha_G2.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Kanawha_G2.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Kanawha_G2.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:Kanawha_G2.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:Kanawha_G2.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:Kanawha_G2.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
 
 kanawha_models:Kanawha_G2.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
@@ -1975,28 +2826,14 @@ kanawha_models:Kanawha_G2.p08 a rascat:RasPlan ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u08 .
 
+kanawha_models:New-LittleRiver.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ] .
+
 kanawha_models:New-LittleRiver.p05 a rascat:RasPlan ;
     dcterms:title "JUN2016_HMS" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03171000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -3.1e-01 ;
-            rascat:pbias 1.955e+01 ;
-            rascat:r2 1e-02 ;
-            rascat:rsr 1.14e+00 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03170000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 3.5e-01 ;
-            rascat:pbias 1.411e+01 ;
-            rascat:r2 6.4e-01 ;
-            rascat:rsr 8.1e-01 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016,
+        kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u05 .
 
@@ -2009,51 +2846,15 @@ lower channel Manning's n
 shifted baseflow
 restart file""" ;
     dcterms:title "NOV2003_HMS" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03171000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 3.8e-01 ;
-            rascat:pbias 9.42e+00 ;
-            rascat:r2 3.9e-01 ;
-            rascat:rsr 7.9e-01 ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03170000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.4e-01 ;
-            rascat:pbias 5.13e+00 ;
-            rascat:r2 9.4e-01 ;
-            rascat:rsr 2.5e-01 ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003,
+        kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u08 .
 
 kanawha_models:New-LittleRiver.p07 a rascat:RasPlan ;
     dcterms:title "JAN1996_HMS" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03170000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9e-01 ;
-            rascat:pbias -2.86e+00 ;
-            rascat:r2 9.5e-01 ;
-            rascat:rsr 3.2e-01 ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03171000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 5.6e-01 ;
-            rascat:pbias 1.31e+00 ;
-            rascat:r2 5.6e-01 ;
-            rascat:rsr 6.6e-01 ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996,
+        kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u07 .
 
@@ -2064,78 +2865,29 @@ kanawha_models:New-LittleRiver.p17 a rascat:RasPlan ;
 
 kanawha_models:New-LittleRiver.p19 a rascat:RasPlan ;
     dcterms:title "JAN1995_HMS" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03171000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 5.7e-01 ;
-            rascat:pbias 9.25e+00 ;
-            rascat:r2 5.8e-01 ;
-            rascat:rsr 6.5e-01 ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03170000 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.5e-01 ;
-            rascat:pbias -5.96e+00 ;
-            rascat:r2 9.6e-01 ;
-            rascat:rsr 2.2e-01 ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995,
+        kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u10 .
+
+kanawha_models:UpperKanawha.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data merged into base LiDAR through GIS mosaic process" ;
+    dcterms:title "USACE Kanawaha CWMS Model" .
+
+kanawha_models:UpperKanawha.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:UpperKanawha.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments, and to create connectivity for major culvert systems in populated areas" ] .
 
 kanawha_models:UpperKanawha.p01 a rascat:RasPlan ;
     dcterms:description """Geometry: Upper Kanawha BLE geometry. Includes Marmet and London L&D. Gate operations from Kanawha CWMS. 
 Flow: June 2016 AORC gridded precipitation. Upstream inflow from USGS Kanawha Falls. Downstream time-stage translated to model outlet from USGS Charleston gage based on friction slope.
 Initial Conditions: Restart file from p.03""" ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "London L&D Tailwater" ;
-            rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.6292e-01 ;
-            rascat:pbias -1.3638e-01 ;
-            rascat:r2 9.8229e-01 ;
-            rascat:rsr 1.9255e-01 ;
-            rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
-            dcterms:title "London L&D Pool" ;
-            rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -1.807e+02 ;
-            rascat:pbias -2.696e-01 ;
-            rascat:r2 7.9179e-03 ;
-            rascat:rsr 1.348e+01 ;
-            rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "Marmet L&D Tailwater" ;
-            rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.2097e-01 ;
-            rascat:pbias 1.2004e-01 ;
-            rascat:r2 9.2979e-01 ;
-            rascat:rsr 2.8112e-01 ;
-            rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "Marmet L&D Pool" ;
-            rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 4.3975e-01 ;
-            rascat:pbias 7.278e-02 ;
-            rascat:r2 5.7783e-01 ;
-            rascat:rsr 7.485e-01 ;
-            rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016,
+        kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Jun2016,
+        kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016,
+        kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u11 .
 
@@ -2144,50 +2896,10 @@ kanawha_models:UpperKanawha.p02 a rascat:RasPlan ;
 Flow: Nov 2003 AORC gridded precipitation. Upstream inflow from USGS Kanawha Falls. Downstream time-stage translated to model outlet from USGS Charleston gage based on friction slope.
 Initial Conditions: Restart file from p.04""" ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "Marmet L&D Pool" ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.3132e-01 ;
-            rascat:pbias 2.3509e-02 ;
-            rascat:r2 9.2922e-01 ;
-            rascat:rsr 4.1071e-01 ;
-            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
-            dcterms:title "London L&D Pool" ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse -5.0493e+01 ;
-            rascat:pbias -1.8653e-01 ;
-            rascat:r2 2.2156e-01 ;
-            rascat:rsr 7.1759e+00 ;
-            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "London L&D Tailwater" ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 9.4446e-01 ;
-            rascat:pbias -1.4871e-01 ;
-            rascat:r2 9.8069e-01 ;
-            rascat:rsr 2.3567e-01 ;
-            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            dcterms:description "Stage hydrograph provided by USACE." ;
-            dcterms:title "Marmet L&D Tailwater" ;
-            rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Stage" ;
-            rascat:nse 8.0228e-01 ;
-            rascat:pbias 6.1883e-02 ;
-            rascat:r2 8.096e-01 ;
-            rascat:rsr 4.4465e-01 ;
-            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003,
+        kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Nov2003,
+        kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003,
+        kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u08 .
 
@@ -2214,6 +2926,9 @@ kanawha_models:UpperKanawha.p06 a rascat:RasPlan ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u02 .
 
+kanawha_models:UpperNew_Lower.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> .
+
 kanawha_models:UpperNew_Lower.p01 a rascat:RasPlan ;
     dcterms:title "Restart" ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
@@ -2221,16 +2936,7 @@ kanawha_models:UpperNew_Lower.p01 a rascat:RasPlan ;
 
 kanawha_models:UpperNew_Lower.p02 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03168000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.24e-01 ;
-            rascat:pbias 3.959e+00 ;
-            rascat:r2 9.78e-01 ;
-            rascat:rsr 2.76e-01 ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u02 .
 
@@ -2239,171 +2945,81 @@ kanawha_models:UpperNew_Lower.p03 a rascat:RasPlan ;
 
 Start time had to change from 07FEB1996 1200 to 02FEB1996 0400 due to a gap in the Upper New - Galax gage record.""" ;
     dcterms:title "Jan1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-02-02T04:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03168000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 3.03e-01 ;
-            rascat:pbias 9.689e+00 ;
-            rascat:r2 3.26e-01 ;
-            rascat:rsr 8.34e-01 ;
-            rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u03 .
 
 kanawha_models:UpperNew_Lower.p04 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03165500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.79e-01 ;
-            rascat:pbias 7.498e+00 ;
-            rascat:r2 9.35e-01 ;
-            rascat:rsr 4.8e-01 ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03168000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.92e-01 ;
-            rascat:pbias 2.6041e+01 ;
-            rascat:r2 9.84e-01 ;
-            rascat:rsr 5.55e-01 ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003,
+        kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u04 .
 
 kanawha_models:UpperNew_Lower.p07 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03168000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -3.43e-01 ;
-            rascat:pbias 5.316e+00 ;
-            rascat:r2 4.9e-02 ;
-            rascat:rsr 1.302e+00 ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03165500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 5.6e-01 ;
-            rascat:pbias 4.2e-01 ;
-            rascat:r2 7.23e-01 ;
-            rascat:rsr 7.23e-01 ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016,
+        kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u05 .
 
+kanawha_models:UpperNew_Upper.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> .
+
 kanawha_models:UpperNew_Upper.p01 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03164000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 8.8e-01 ;
-            rascat:pbias 2.077e+01 ;
-            rascat:r2 9.1e-01 ;
-            rascat:rsr 3.4e-01 ;
-            rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03161000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.6e-01 ;
-            rascat:pbias -5.26e+00 ;
-            rascat:r2 9.7e-01 ;
-            rascat:rsr 2.1e-01 ;
-            rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995,
+        kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u01 .
 
 kanawha_models:UpperNew_Upper.p02 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03161000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.7e-01 ;
-            rascat:pbias -7.82e+00 ;
-            rascat:r2 9.7e-01 ;
-            rascat:rsr 1.8e-01 ;
-            rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03164000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.2e-01 ;
-            rascat:pbias 4.4e+01 ;
-            rascat:r2 8e-01 ;
-            rascat:rsr 6.2e-01 ;
-            rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003,
+        kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u02 .
 
 kanawha_models:UpperNew_Upper.p03 a rascat:RasPlan ;
     dcterms:title "Jan1996" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03164000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -3.4e-01 ;
-            rascat:pbias 5.675e+01 ;
-            rascat:r2 3.3e-01 ;
-            rascat:rsr 1.16e+00 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03161000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.6e-01 ;
-            rascat:pbias -2.61e+00 ;
-            rascat:r2 7.9e-01 ;
-            rascat:rsr 4.8e-01 ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996,
+        kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u03 .
 
 kanawha_models:UpperNew_Upper.p04 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03164000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -7.27e+00 ;
-            rascat:pbias 5.876e+01 ;
-            rascat:r2 1.4e-01 ;
-            rascat:rsr 2.87e+00 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ],
-        [ a rascat:Hydrograph ;
-            rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03161000 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -1.22e+00 ;
-            rascat:pbias -8.08e+00 ;
-            rascat:r2 2e-02 ;
-            rascat:rsr 1.49e+00 ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016,
+        kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u04 .
 
 kanawha_models:UpperNew_Upper.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "RestartFile" .
+
+kanawha_models:WatershedG3.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG3.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG3.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:WatershedG3.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG3.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG3.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:WatershedG3.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG3.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG3.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
 
 kanawha_models:WatershedG3.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
@@ -2431,67 +3047,51 @@ kanawha_models:WatershedG3.p04 a rascat:RasPlan ;
 
 kanawha_models:WatershedG3.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1995" ;
-            rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:fromStreamgage usgs_gages:03182500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 1.3088e-01 ;
-            rascat:pbias 3.516e+01 ;
-            rascat:r2 6.1693e-01 ;
-            rascat:rsr 9.3227e-01 ;
-            rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u01 .
 
 kanawha_models:WatershedG3.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1996" ;
-            rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:fromStreamgage usgs_gages:03182500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 5.2781e-01 ;
-            rascat:pbias 3.5098e+01 ;
-            rascat:r2 9.1635e-01 ;
-            rascat:rsr 6.8716e-01 ;
-            rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u02 .
 
 kanawha_models:WatershedG3.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in November 2003" ;
-            rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:fromStreamgage usgs_gages:03182500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 6.3691e-01 ;
-            rascat:pbias 4.5403e+01 ;
-            rascat:r2 9.099e-01 ;
-            rascat:rsr 6.0257e-01 ;
-            rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u03 .
 
 kanawha_models:WatershedG3.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in June 2016" ;
-            rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:fromStreamgage usgs_gages:03182500 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 9.627e-01 ;
-            rascat:pbias 1.3292e+01 ;
-            rascat:r2 9.8257e-01 ;
-            rascat:rsr 1.9314e-01 ;
-            rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u04 .
+
+kanawha_models:WatershedG4.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG4.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG4.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:WatershedG4.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG4.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG4.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:WatershedG4.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG4.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG4.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
 
 kanawha_models:WatershedG4.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
@@ -2537,6 +3137,30 @@ kanawha_models:WatershedG4.p08 a rascat:RasPlan ;
     rascat:hasGeometry kanawha_models:WatershedG4.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u04 .
 
+kanawha_models:WatershedG9.g01.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG9.g01.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG9.g01.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:WatershedG9.g02.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG9.g02.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG9.g02.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
+kanawha_models:WatershedG9.g03.bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+
+kanawha_models:WatershedG9.g03.terrain a rascat:Terrain ;
+    rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
+    rascat:hasBathymetry kanawha_models:WatershedG9.g03.bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+
 kanawha_models:WatershedG9.p01 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
@@ -2557,57 +3181,25 @@ kanawha_models:WatershedG9.p03 a rascat:RasPlan ;
 kanawha_models:WatershedG9.p04 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jun2016 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.2673e-01 ;
-            rascat:pbias 2.8095e+01 ;
-            rascat:r2 9.4184e-01 ;
-            rascat:rsr 5.2275e-01 ;
-            rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u04 .
 
 kanawha_models:WatershedG9.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1995 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -1.5141e+00 ;
-            rascat:pbias 4.5535e+01 ;
-            rascat:r2 9.0313e-01 ;
-            rascat:rsr 1.5856e+00 ;
-            rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01 .
 
 kanawha_models:WatershedG9.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Jan1996 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse -5.8891e-02 ;
-            rascat:pbias 6.035e+01 ;
-            rascat:r2 8.3038e-01 ;
-            rascat:rsr 1.029e+00 ;
-            rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u02 .
 
 kanawha_models:WatershedG9.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasCalibrationHydrograph [ a rascat:Hydrograph ;
-            rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
-            rascat:fromHydroEvent kanawha_events:Nov2003 ;
-            rascat:hydrographType "Flow" ;
-            rascat:nse 7.2673e-01 ;
-            rascat:pbias 2.8095e+01 ;
-            rascat:r2 9.4184e-01 ;
-            rascat:rsr 5.2275e-01 ;
-            rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ] ;
+    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u03 .
 
@@ -2728,13 +3320,8 @@ kanawha_models:BasinG6.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:BasinG6.g03.terrain .
 
 kanawha_models:BasinG6.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Inital Conditions" ;
@@ -2908,14 +3495,11 @@ kanawha_models:ElkMiddle.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMaxCellSize 150 ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Remote Sensing Data processed by WSP" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Remote Sensing Data processed by WSP" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:ElkMiddle.g02.terrain .
 
 kanawha_models:ElkMiddle.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Nov2003" ;
@@ -2965,13 +3549,8 @@ kanawha_models:G5.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:G5.g03.terrain .
 
 kanawha_models:G5.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
@@ -3129,13 +3708,8 @@ kanawha_models:Greenbrier_G7.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G7.g03.terrain .
 
 kanawha_models:Greenbrier_G7.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 IC" ;
@@ -3203,13 +3777,8 @@ kanawha_models:Greenbrier_G8.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G8.g03.terrain .
 
 kanawha_models:Greenbrier_G8.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 IC" ;
@@ -3349,13 +3918,8 @@ kanawha_models:Kanawha_G2.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Kanawha_G2.g03.terrain .
 
 kanawha_models:Kanawha_G2.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Initial Conditions" ;
@@ -3632,13 +4196,8 @@ kanawha_models:WatershedG4.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG4.g03.terrain .
 
 kanawha_models:WatershedG9.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_1996" ;
@@ -3652,16 +4211,8 @@ kanawha_models:WatershedG9.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
-
-ffrd_orgs:ARC_JV a foaf:Organization ;
-    foaf:name "ARC JV" .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG9.g03.terrain .
 
 ffrd_people:Daniyal_Siddiqui a foaf:Person ;
     foaf:Organization ffrd_orgs:Baker ;
@@ -3688,6 +4239,11 @@ usgs_gages:03165500 a rascat:Streamgage ;
     dcterms:publisher "USGS" ;
     dcterms:title "New River at Ivanhoe, VA" .
 
+usgs_gages:03188900 a rascat:Streamgage ;
+    dcterms:identifier "03188900" ;
+    dcterms:publisher "USGS" ;
+    dcterms:title "Laurel Creek Near Fenwick, WV" .
+
 usgs_gages:03190000 a rascat:Streamgage ;
     dcterms:identifier "03190000" ;
     dcterms:publisher "USGS" ;
@@ -3697,6 +4253,26 @@ usgs_gages:03198350 a rascat:Streamgage ;
     dcterms:identifier "03198350" ;
     dcterms:publisher "USGS" ;
     dcterms:title "Clear Fork at Whitesville, WV" .
+
+<https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#London%20L&D%20Pool> a rascat:Streamgage ;
+    dcterms:identifier "USACE_London_LD_Pool" ;
+    dcterms:publisher "USACE" ;
+    dcterms:title "London L&D Pool" .
+
+<https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#London%20L&D%20Tailwater> a rascat:Streamgage ;
+    dcterms:identifier "USACE_London_LD_Tailwater" ;
+    dcterms:publisher "USACE" ;
+    dcterms:title "London L&D Tailwater" .
+
+<https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#Marmet%20L&D%20Pool> a rascat:Streamgage ;
+    dcterms:identifier "USACE_Marmet_LD_Pool" ;
+    dcterms:publisher "USACE" ;
+    dcterms:title "Marmet L&D Pool" .
+
+<https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#Marmet%20L&D%20Tailwater> a rascat:Streamgage ;
+    dcterms:identifier "USACE_Marmet_LD_Tailwater" ;
+    dcterms:publisher "USACE" ;
+    dcterms:title "Marmet L&D Tailwater" .
 
 <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/> a rascat:Structures ;
     dcterms:description "Structures pulled from existing 1D HEC-RAS models where available." ;
@@ -3749,17 +4325,11 @@ kanawha_models:Greenbrier_G7.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G7.g01.terrain .
 
 kanawha_models:Greenbrier_G8.g01 a rascat:RasGeometry ;
     dcterms:title "Greenbrier_G8_LiDAR" ;
@@ -3772,17 +4342,11 @@ kanawha_models:Greenbrier_G8.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G8.g01.terrain .
 
 kanawha_models:Kanawha_G1.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1_2016" ;
@@ -3795,17 +4359,11 @@ kanawha_models:Kanawha_G1.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Kanawha_G1.g02.terrain .
 
 kanawha_models:Kanawha_G1.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1_1996" ;
@@ -3819,13 +4377,8 @@ kanawha_models:Kanawha_G1.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Kanawha_G1.g03.terrain .
 
 kanawha_models:Kanawha_G2.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G2_2016" ;
@@ -3838,17 +4391,11 @@ kanawha_models:Kanawha_G2.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Kanawha_G2.g02.terrain .
 
 kanawha_models:WatershedG3.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_1996" ;
@@ -3862,13 +4409,8 @@ kanawha_models:WatershedG3.g03 a rascat:RasGeometry ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG3.g03.terrain .
 
 kanawha_models:WatershedG3.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996" ;
@@ -3908,17 +4450,11 @@ kanawha_models:WatershedG4.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG4.g02.terrain .
 
 kanawha_models:WatershedG4.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
@@ -3967,17 +4503,11 @@ kanawha_models:WatershedG9.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG9.g02.terrain .
 
 kanawha_models:WatershedG9.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
@@ -4015,11 +4545,6 @@ kanawha_models:WatershedG9.u04 a rascat:RasUnsteadyFlow ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
-ffrd_orgs:Baker a foaf:Organization ;
-    foaf:Organization ffrd_orgs:ARC_JV ;
-    foaf:homepage <https://mbakerintl.com/> ;
-    foaf:name "Michael Baker Intl" .
-
 ffrd_people:Dami_George a foaf:Person ;
     foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "dami.george@wsp.com" ;
@@ -4040,6 +4565,12 @@ usgs_gages:03191500 a rascat:Streamgage ;
     dcterms:publisher "USGS" ;
     dcterms:title "Peters Creek Near Lockwood, WV" .
 
+kanawha_misc:baker_landuse a rascat:LanduseLandcover ;
+    dcterms:creator ffrd_orgs:ARC_JV,
+        ffrd_orgs:Baker ;
+    dcterms:description "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022" ;
+    dcterms:title "Baker (ARC) ML-based land use" .
+
 kanawha_models:BasinG6.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G6_2016" ;
     rascat:hasMesh2D [ a rascat:Mesh2D ;
@@ -4051,17 +4582,11 @@ kanawha_models:BasinG6.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:BasinG6.g02.terrain .
 
 kanawha_models:ElkMiddle.g01 a rascat:RasGeometry ;
     dcterms:title "ElkMiddle" ;
@@ -4073,17 +4598,11 @@ kanawha_models:ElkMiddle.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMaxCellSize 150 ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Remote Sensing Data processed by WSP" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Remote Sensing Data processed by WSP" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from existing CWMS 1D HEC-RAS model. Channel raster developed and mosaiced to DEM and then incorporated into model" ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments. Hydroflattened major rivers" ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:ElkMiddle.g01.terrain .
 
 kanawha_models:G5.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G5_2016" ;
@@ -4096,17 +4615,11 @@ kanawha_models:G5.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:G5.g02.terrain .
 
 kanawha_models:Greenbrier_G7.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G7_2016" ;
@@ -4119,17 +4632,11 @@ kanawha_models:Greenbrier_G7.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G7.g02.terrain .
 
 kanawha_models:Greenbrier_G8.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G8_2016" ;
@@ -4142,17 +4649,11 @@ kanawha_models:Greenbrier_G8.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G8.g02.terrain .
 
 kanawha_models:WatershedG3.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
@@ -4165,17 +4666,11 @@ kanawha_models:WatershedG3.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG3.g01.terrain .
 
 kanawha_models:WatershedG3.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_2016" ;
@@ -4188,17 +4683,19 @@ kanawha_models:WatershedG3.g02 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG3.g02.terrain .
+
+ffrd_orgs:ARC_JV a foaf:Organization ;
+    foaf:name "ARC JV" .
+
+ffrd_orgs:Baker a foaf:Organization ;
+    foaf:Organization ffrd_orgs:ARC_JV ;
+    foaf:homepage <https://mbakerintl.com/> ;
+    foaf:name "Michael Baker Intl" .
 
 usgs_gages:03161000 a rascat:Streamgage ;
     dcterms:identifier "03161000" ;
@@ -4248,6 +4745,11 @@ usgs_gages:03182500 a rascat:Streamgage ;
 usgs_gages:03183500 a rascat:Streamgage ;
     dcterms:identifier "03183500" ;
     dcterms:publisher "USGS" ;
+    dcterms:title "Greenbrier River at Alderson, WV" .
+
+usgs_gages:03184000 a rascat:Streamgage ;
+    dcterms:identifier "03184000" ;
+    dcterms:publisher "USGS" ;
     dcterms:title "Greenbrier River at Hilldale, WV" .
 
 usgs_gages:03186500 a rascat:Streamgage ;
@@ -4281,17 +4783,11 @@ kanawha_models:BasinG6.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:BasinG6.g01.terrain .
 
 kanawha_models:BluestoneLocal.g01 a rascat:RasGeometry ;
     dcterms:title "BL-1" ;
@@ -4307,9 +4803,7 @@ kanawha_models:BluestoneLocal.g01 a rascat:RasGeometry ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
             rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ] ] .
+    rascat:hasTerrain kanawha_models:BluestoneLocal.g01.terrain .
 
 kanawha_models:Bluestone_Upper.g07 a rascat:RasGeometry ;
     dcterms:title "400ft_Refined_100ft_NoSCS" ;
@@ -4325,9 +4819,7 @@ kanawha_models:Bluestone_Upper.g07 a rascat:RasGeometry ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
             rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and dam/berm embankments. LiDAR-processed DEM was hydroflattened by provider." ] ] .
+    rascat:hasTerrain kanawha_models:Bluestone_Upper.g07.terrain .
 
 kanawha_models:CoalRiver.g01 a rascat:RasGeometry ;
     dcterms:description "Nominal rectangular cell spacing of 500' x 500', refined along stream corridors and other breaklines areas to be approximately 100' cells. No losses (e.g. SCS CN) modeled directly in HEC-RAS." ;
@@ -4344,8 +4836,7 @@ kanawha_models:CoalRiver.g01 a rascat:RasGeometry ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
             rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ] .
+    rascat:hasTerrain kanawha_models:CoalRiver.g01.terrain .
 
 kanawha_models:G5.g01 a rascat:RasGeometry ;
     dcterms:title "GreenbrierBasinG5_LiDAR" ;
@@ -4358,17 +4849,11 @@ kanawha_models:G5.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:G5.g01.terrain .
 
 kanawha_models:GSummersville_B.g01 a rascat:RasGeometry ;
     dcterms:title "GauleySummersville_Existing" ;
@@ -4385,11 +4870,7 @@ kanawha_models:GSummersville_B.g01 a rascat:RasGeometry ;
     rascat:hasRoughness [ a rascat:Roughness ;
             rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
     rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/> ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] ] .
+    rascat:hasTerrain kanawha_models:GSummersville_B.g01.terrain .
 
 kanawha_models:GauleyLower_BLE_FEM.g01 a rascat:RasGeometry ;
     dcterms:title "Gauley_Lower" ;
@@ -4401,18 +4882,12 @@ kanawha_models:GauleyLower_BLE_FEM.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMaxCellSize 50 ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:baker_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022" ] ] ;
+            rascat:hasLanduseLandcover kanawha_misc:baker_landuse ] ;
     rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/> ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] ] .
+    rascat:hasTerrain kanawha_models:GauleyLower_BLE_FEM.g01.terrain .
 
 kanawha_models:Kanawha_G1.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1" ;
@@ -4425,17 +4900,11 @@ kanawha_models:Kanawha_G1.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Kanawha_G1.g01.terrain .
 
 kanawha_models:UpperNew_Upper.g01 a rascat:RasGeometry ;
     dcterms:title "UpperNew_Upper_geom" ;
@@ -4451,8 +4920,7 @@ kanawha_models:UpperNew_Upper.g01 a rascat:RasGeometry ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
             rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ] .
+    rascat:hasTerrain kanawha_models:UpperNew_Upper.g01.terrain .
 
 usgs_gages:03196800 a rascat:Streamgage ;
     dcterms:identifier "03196800" ;
@@ -4470,17 +4938,11 @@ kanawha_models:Kanawha_G2.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:Kanawha_G2.g01.terrain .
 
 kanawha_models:New-LittleRiver.g01 a rascat:RasGeometry ;
     dcterms:title "New_Little_River" ;
@@ -4494,9 +4956,7 @@ kanawha_models:New-LittleRiver.g01 a rascat:RasGeometry ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
             rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ] ] .
+    rascat:hasTerrain kanawha_models:New-LittleRiver.g01.terrain .
 
 kanawha_models:UpperNew_Lower.g03 a rascat:RasGeometry ;
     dcterms:title "Simplified" ;
@@ -4514,8 +4974,7 @@ kanawha_models:UpperNew_Lower.g03 a rascat:RasGeometry ;
             dcterms:description "Description of hydraulic data and water surface elevations of the dam was used to create a rating curve" ;
             dcterms:relation <http://claytorhydro.com/lib/docs/ClaytorWaterManagementPlanJune2009asapprovedbyFERCDec2011.pdf>,
                 <https://hydroreform.org/wp-content/uploads/2020/09/New-River-Virginia-Final.pdf> ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ] .
+    rascat:hasTerrain kanawha_models:UpperNew_Lower.g03.terrain .
 
 kanawha_models:WatershedG4.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
@@ -4528,17 +4987,11 @@ kanawha_models:WatershedG4.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG4.g01.terrain .
 
 kanawha_models:WatershedG9.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
@@ -4551,17 +5004,11 @@ kanawha_models:WatershedG9.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
             dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "Custom land cover analysis of NAIP 2022 imagery" ] ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] ] .
+            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
+    rascat:hasTerrain kanawha_models:WatershedG9.g01.terrain .
 
 kanawha_models:GSummersville_C.g01 a rascat:RasGeometry ;
     dcterms:title "GauleySummersville_Existing" ;
@@ -4573,18 +5020,12 @@ kanawha_models:GSummersville_C.g01 a rascat:RasGeometry ;
             rascat:refinementRegionsMaxCellSize 200 ;
             rascat:refinementRegionsMinCellSize 50 ] ;
     rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022" ] ;
+            rascat:hasLanduseLandcover kanawha_misc:baker_landuse ;
             rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
     rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover [ a rascat:LanduseLandcover ;
-                    dcterms:description "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022" ] ] ;
+            rascat:hasLanduseLandcover kanawha_misc:baker_landuse ] ;
     rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/> ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] ] .
+    rascat:hasTerrain kanawha_models:GSummersville_C.g01.terrain .
 
 kanawha_models:UpperKanawha.g01 a rascat:RasGeometry ;
     dcterms:title "UpperKanawha" ;
@@ -4603,12 +5044,7 @@ kanawha_models:UpperKanawha.g01 a rascat:RasGeometry ;
     rascat:hasStructures [ a rascat:Structures ;
             dcterms:description "London/Marmet L&D Structures and Gate operations copied from USACE CWMS Model" ;
             dcterms:title "USACE Kanawaha CWMS Model" ] ;
-    rascat:hasTerrain [ a rascat:Terrain ;
-            rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-            rascat:hasBathymetry [ a rascat:Bathymetry ;
-                    dcterms:description "Channel data merged into base LiDAR through GIS mosaic process" ;
-                    dcterms:title "USACE Kanawaha CWMS Model" ] ;
-            rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments, and to create connectivity for major culvert systems in populated areas" ] ] .
+    rascat:hasTerrain kanawha_models:UpperKanawha.g01.terrain .
 
 usgs_gages:03197000 a rascat:Streamgage ;
     dcterms:identifier "03197000" ;
@@ -4624,6 +5060,11 @@ usgs_gages:03192000 a rascat:Streamgage ;
     dcterms:identifier "03192000" ;
     dcterms:publisher "USGS" ;
     dcterms:title "Gauley River Above Belva, WV" .
+
+<https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> a rascat:Streamgage ;
+    dcterms:identifier "USACE_Summersville_Lake" ;
+    dcterms:publisher "USACE" ;
+    dcterms:title "Summersville Lake" .
 
 ffrd_orgs:AECOM a foaf:Organization ;
     foaf:Organization ffrd_orgs:Compass_JV ;
@@ -4645,15 +5086,15 @@ ffrd_orgs:WSP a foaf:Organization ;
     foaf:homepage <https://www.wsp.com/> ;
     foaf:name "WSP, Inc." .
 
-usgs_gages:03189100 a rascat:Streamgage ;
-    dcterms:identifier "03189100" ;
-    dcterms:publisher "USGS" ;
-    dcterms:title "Gauley River Near Craigsville, WV" .
-
 usgs_gages:03187500 a rascat:Streamgage ;
     dcterms:identifier "03187500" ;
     dcterms:publisher "USGS" ;
     dcterms:title "Cranberry River Near Richwood, WV" .
+
+usgs_gages:03189100 a rascat:Streamgage ;
+    dcterms:identifier "03189100" ;
+    dcterms:publisher "USGS" ;
+    dcterms:title "Gauley River Near Craigsville, WV" .
 
 <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> a rascat:LanduseLandcover ;
     dcterms:description "National Land Cover Database 2019 (CONUS)" ;
@@ -4670,6 +5111,12 @@ kanawha_models:mmc_albers_ft.prj a rascat:Projection ;
 <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> a rascat:DEM ;
     dcterms:description "Digital Elevation Model for the Kanawha River Basin, based on USGS 3DEP data." ;
     dcterms:title "Kanawha River Basin DEM" .
+
+kanawha_misc:wsp_landuse a rascat:LanduseLandcover ;
+    dcterms:creator ffrd_orgs:ARC_JV,
+        ffrd_orgs:WSP ;
+    dcterms:description "Custom machine learning land cover analysis of NAIP 2022 imagery" ;
+    dcterms:title "WSP (ARC) ML-based land use" .
 
 kanawha_events:Jan1996 a rascat:HydroEvent ;
     dcterms:title "January 1996" ;

--- a/kanawha.ttl
+++ b/kanawha.ttl
@@ -512,7 +512,7 @@ kanawha_models:WatershedG9.prj a rascat:RasModel ;
     rascat:status "Final" ;
     rascat:verticalDatum "NAVD88" .
 
-kanawha_calibration:BasinG6_03182888_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:BasinG6_03182888_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2023-03-24T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03182888 ;
@@ -523,7 +523,7 @@ kanawha_calibration:BasinG6_03182888_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 5.9411e-01 ;
     rascat:startDateTime "2007-10-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03177120 ;
@@ -534,7 +534,7 @@ kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.14e+00 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-24T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03179800 ;
@@ -545,7 +545,7 @@ kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 2.53e-01 ;
     rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-30T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03179800 ;
@@ -556,7 +556,7 @@ kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 3.6e-01 ;
     rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03179800 ;
@@ -567,7 +567,7 @@ kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.11e+00 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-27T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03179800 ;
@@ -578,7 +578,7 @@ kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 2.3e-01 ;
     rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03177710 ;
@@ -588,7 +588,7 @@ kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 6.6e-01 ;
     rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03177710 ;
@@ -599,7 +599,7 @@ kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 3.3e-01 ;
     rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03177710 ;
@@ -610,7 +610,7 @@ kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.09e+00 ;
     rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03179000 ;
@@ -620,7 +620,7 @@ kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 3.9e-01 ;
     rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03179000 ;
@@ -631,7 +631,7 @@ kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 4.2e-01 ;
     rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03179000 ;
@@ -642,7 +642,7 @@ kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 9.9e-01 ;
     rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03179000 ;
@@ -652,7 +652,7 @@ kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 2.7e-01 ;
     rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03198350_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03198350_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03198350 ;
@@ -663,7 +663,7 @@ kanawha_calibration:CoalRiver_03198350_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 6.5e-01 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03198350_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03198350_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03198350 ;
@@ -674,7 +674,7 @@ kanawha_calibration:CoalRiver_03198350_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 3.2e-01 ;
     rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03198500_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03198500_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03198500 ;
@@ -685,7 +685,7 @@ kanawha_calibration:CoalRiver_03198500_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 9.5e-01 ;
     rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03198500_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03198500_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03198500 ;
@@ -696,7 +696,7 @@ kanawha_calibration:CoalRiver_03198500_Flow_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 1.67e+00 ;
     rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03198500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03198500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03198500 ;
@@ -707,7 +707,7 @@ kanawha_calibration:CoalRiver_03198500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 8e-01 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03198500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03198500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03198500 ;
@@ -718,7 +718,7 @@ kanawha_calibration:CoalRiver_03198500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 3.9e-01 ;
     rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03200500 ;
@@ -729,7 +729,7 @@ kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 8.4e-01 ;
     rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03200500 ;
@@ -740,7 +740,7 @@ kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 5.1e-01 ;
     rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03200500 ;
@@ -751,7 +751,7 @@ kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 9.6e-01 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03200500 ;
@@ -762,7 +762,7 @@ kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 3.6e-01 ;
     rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03196500 ;
@@ -773,7 +773,7 @@ kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 8.3896e-01 ;
     rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03196600 ;
@@ -784,7 +784,7 @@ kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1.3554e+00 ;
     rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03196600 ;
@@ -795,7 +795,7 @@ kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 7.8902e-01 ;
     rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196600_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196600_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03196600 ;
@@ -806,7 +806,7 @@ kanawha_calibration:ElkMiddle_03196600_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.0997e+00 ;
     rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03196600 ;
@@ -817,7 +817,7 @@ kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 8.2996e-01 ;
     rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196800_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196800_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03196800 ;
@@ -828,7 +828,7 @@ kanawha_calibration:ElkMiddle_03196800_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 6.2162e-01 ;
     rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196800_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196800_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03196800 ;
@@ -839,7 +839,7 @@ kanawha_calibration:ElkMiddle_03196800_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1.0726e+00 ;
     rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03196800 ;
@@ -850,7 +850,7 @@ kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 8.4782e-01 ;
     rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196800_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196800_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03196800 ;
@@ -861,7 +861,7 @@ kanawha_calibration:ElkMiddle_03196800_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 6.2702e-01 ;
     rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03196800_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03196800_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03196800 ;
@@ -872,7 +872,7 @@ kanawha_calibration:ElkMiddle_03196800_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 3.6328e-01 ;
     rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03197000 ;
@@ -883,7 +883,7 @@ kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 7.5204e-01 ;
     rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03197000_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03197000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03197000 ;
@@ -894,7 +894,7 @@ kanawha_calibration:ElkMiddle_03197000_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 2.5266e-01 ;
     rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03197000 ;
@@ -905,7 +905,7 @@ kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 3.0843e-01 ;
     rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03197000 ;
@@ -916,7 +916,7 @@ kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1.5419e+00 ;
     rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03197000 ;
@@ -927,7 +927,7 @@ kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 1.4724e+00 ;
     rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03197000_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03197000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03197000 ;
@@ -938,7 +938,7 @@ kanawha_calibration:ElkMiddle_03197000_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 4.7899e-01 ;
     rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03197000 ;
@@ -949,7 +949,7 @@ kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 5.1156e-01 ;
     rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03186500 ;
@@ -960,7 +960,7 @@ kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.9e-01 ;
     rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03186500 ;
@@ -971,7 +971,7 @@ kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 3.7e-01 ;
     rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03187000 ;
@@ -982,7 +982,7 @@ kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1.18e+00 ;
     rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03187000 ;
@@ -993,7 +993,7 @@ kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 1.33e+00 ;
     rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187000_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03187000 ;
@@ -1004,7 +1004,7 @@ kanawha_calibration:GSummersville_B_03187000_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 5e-01 ;
     rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187000_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03187000 ;
@@ -1015,7 +1015,7 @@ kanawha_calibration:GSummersville_B_03187000_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 7.5e-01 ;
     rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1026,7 +1026,7 @@ kanawha_calibration:GSummersville_B_03187500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 5.3e-01 ;
     rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1037,7 +1037,7 @@ kanawha_calibration:GSummersville_B_03187500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 2.2e-01 ;
     rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187500_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187500_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1048,7 +1048,7 @@ kanawha_calibration:GSummersville_B_03187500_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 2.03e+00 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187500_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187500_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1059,7 +1059,7 @@ kanawha_calibration:GSummersville_B_03187500_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 2.22e+00 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187500_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1070,7 +1070,7 @@ kanawha_calibration:GSummersville_B_03187500_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.53e+00 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03187500_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03187500_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1081,7 +1081,7 @@ kanawha_calibration:GSummersville_B_03187500_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 1.19e+00 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03188900_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03188900_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03188900 ;
@@ -1092,7 +1092,7 @@ kanawha_calibration:GSummersville_B_03188900_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 3e-01 ;
     rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03189100_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03189100_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1103,7 +1103,7 @@ kanawha_calibration:GSummersville_B_03189100_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 2e-01 ;
     rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03189100_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03189100_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1114,7 +1114,7 @@ kanawha_calibration:GSummersville_B_03189100_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 3.5e-01 ;
     rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1125,7 +1125,7 @@ kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 3.4e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1136,7 +1136,7 @@ kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 6.4e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03189100_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03189100_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1147,7 +1147,7 @@ kanawha_calibration:GSummersville_B_03189100_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 3.1e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_03189100_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_03189100_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1158,7 +1158,7 @@ kanawha_calibration:GSummersville_B_03189100_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 4.8e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
@@ -1169,7 +1169,7 @@ kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 a rasc
     rascat:rsr 1.05e+00 ;
     rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
@@ -1180,7 +1180,7 @@ kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 a rasc
     rascat:rsr 1.02e+00 ;
     rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
@@ -1191,7 +1191,7 @@ kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jun2016 a rasc
     rascat:rsr 3.4e-01 ;
     rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
@@ -1202,7 +1202,7 @@ kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Nov2003 a rasc
     rascat:rsr 6.53e-01 ;
     rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03186500 ;
@@ -1213,7 +1213,7 @@ kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 2.5e-01 ;
     rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03186500 ;
@@ -1224,7 +1224,7 @@ kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 3.5e-01 ;
     rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03187000 ;
@@ -1235,7 +1235,7 @@ kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1e+00 ;
     rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03187000 ;
@@ -1246,7 +1246,7 @@ kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 7.1e-01 ;
     rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187000_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03187000 ;
@@ -1257,7 +1257,7 @@ kanawha_calibration:GSummersville_C_03187000_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 5.4e-01 ;
     rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187000_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03187000 ;
@@ -1268,7 +1268,7 @@ kanawha_calibration:GSummersville_C_03187000_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 2.9e-01 ;
     rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1279,7 +1279,7 @@ kanawha_calibration:GSummersville_C_03187500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 5.2e-01 ;
     rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1290,7 +1290,7 @@ kanawha_calibration:GSummersville_C_03187500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 4.5e-01 ;
     rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187500_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187500_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1301,7 +1301,7 @@ kanawha_calibration:GSummersville_C_03187500_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1.01e+00 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187500_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187500_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1312,7 +1312,7 @@ kanawha_calibration:GSummersville_C_03187500_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 1.59e+00 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187500_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1323,7 +1323,7 @@ kanawha_calibration:GSummersville_C_03187500_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1e+00 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03187500_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03187500_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03187500 ;
@@ -1334,7 +1334,7 @@ kanawha_calibration:GSummersville_C_03187500_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 5.9e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03188900_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03188900_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03188900 ;
@@ -1345,7 +1345,7 @@ kanawha_calibration:GSummersville_C_03188900_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 3.4e-01 ;
     rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03189100_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03189100_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1356,7 +1356,7 @@ kanawha_calibration:GSummersville_C_03189100_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 2.9e-01 ;
     rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03189100_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03189100_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1367,7 +1367,7 @@ kanawha_calibration:GSummersville_C_03189100_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 4.4e-01 ;
     rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1378,7 +1378,7 @@ kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 7.1e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1389,7 +1389,7 @@ kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 6.7e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03189100_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03189100_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1400,7 +1400,7 @@ kanawha_calibration:GSummersville_C_03189100_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 4.1e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_03189100_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_03189100_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03189100 ;
@@ -1411,7 +1411,7 @@ kanawha_calibration:GSummersville_C_03189100_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 5.3e-01 ;
     rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
@@ -1422,7 +1422,7 @@ kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 a rasc
     rascat:rsr 1.86e+00 ;
     rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
@@ -1433,7 +1433,7 @@ kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 a rasc
     rascat:rsr 1.1e+00 ;
     rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
@@ -1444,7 +1444,7 @@ kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jun2016 a rasc
     rascat:rsr 3.5e-01 ;
     rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage <https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug> ;
@@ -1455,7 +1455,7 @@ kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Nov2003 a rasc
     rascat:rsr 3.5e-01 ;
     rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03190000 ;
@@ -1466,7 +1466,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016 a rascat:Hydrograp
     rascat:rsr 3.76e-01 ;
     rascat:startDateTime "2012-08-30T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03190000_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03190000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03190000 ;
@@ -1477,7 +1477,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03190000_Stage_Jun2016 a rascat:Hydrogra
     rascat:rsr 2.959e-01 ;
     rascat:startDateTime "2014-04-02T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03191500 ;
@@ -1488,7 +1488,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Jun2016 a rascat:Hydrograp
     rascat:rsr 5.77e-01 ;
     rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03191500 ;
@@ -1499,7 +1499,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003 a rascat:Hydrograp
     rascat:rsr 6.53e-01 ;
     rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03191500_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03191500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03191500 ;
@@ -1510,7 +1510,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03191500_Stage_Jun2016 a rascat:Hydrogra
     rascat:rsr 5.56e-01 ;
     rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03192000 ;
@@ -1521,7 +1521,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995 a rascat:Hydrograp
     rascat:rsr 2.18e-01 ;
     rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03192000 ;
@@ -1532,7 +1532,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996 a rascat:Hydrograp
     rascat:rsr 5.93e-01 ;
     rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03192000 ;
@@ -1543,7 +1543,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jun2016 a rascat:Hydrograp
     rascat:rsr 2.95e-01 ;
     rascat:startDateTime "2016-04-30T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03192000 ;
@@ -1554,7 +1554,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003 a rascat:Hydrograp
     rascat:rsr 6.38e-01 ;
     rascat:startDateTime "2003-09-30T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03192000 ;
@@ -1565,7 +1565,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 a rascat:Hydrogra
     rascat:rsr 7.15e-01 ;
     rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03192000 ;
@@ -1576,7 +1576,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 a rascat:Hydrogra
     rascat:rsr 4.15e-01 ;
     rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03192000 ;
@@ -1587,7 +1587,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jun2016 a rascat:Hydrogra
     rascat:rsr 4.67e-01 ;
     rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03192000 ;
@@ -1598,7 +1598,7 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 a rascat:Hydrogra
     rascat:rsr 6.12e-01 ;
     rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03183500 ;
@@ -1609,7 +1609,7 @@ kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1.6907e+00 ;
     rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03183500 ;
@@ -1620,7 +1620,7 @@ kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 1.3993e+00 ;
     rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03183500 ;
@@ -1631,7 +1631,7 @@ kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 3.7249e-01 ;
     rascat:startDateTime "2016-04-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03183500 ;
@@ -1642,7 +1642,7 @@ kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 4.9232e-01 ;
     rascat:startDateTime "2003-09-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03180500 ;
@@ -1653,7 +1653,7 @@ kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1.0849e+00 ;
     rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03180500 ;
@@ -1664,7 +1664,7 @@ kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 7.5269e-01 ;
     rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03180500 ;
@@ -1675,7 +1675,7 @@ kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 7.3549e-01 ;
     rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03180500 ;
@@ -1686,7 +1686,7 @@ kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 8.2889e-01 ;
     rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03170000 ;
@@ -1697,7 +1697,7 @@ kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 2.2e-01 ;
     rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
 
-kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03170000 ;
@@ -1708,7 +1708,7 @@ kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 3.2e-01 ;
     rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03170000 ;
@@ -1719,7 +1719,7 @@ kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 8.1e-01 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03170000 ;
@@ -1730,7 +1730,7 @@ kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 2.5e-01 ;
     rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03171000 ;
@@ -1741,7 +1741,7 @@ kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 6.5e-01 ;
     rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
 
-kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03171000 ;
@@ -1752,7 +1752,7 @@ kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 6.6e-01 ;
     rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03171000 ;
@@ -1763,7 +1763,7 @@ kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.14e+00 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03171000 ;
@@ -1774,7 +1774,7 @@ kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 7.9e-01 ;
     rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
     dcterms:title "London L&D Pool" ;
     rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
@@ -1787,7 +1787,7 @@ kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016 a rascat:Hyd
     rascat:rsr 1.348e+01 ;
     rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
     dcterms:title "London L&D Pool" ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
@@ -1800,7 +1800,7 @@ kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003 a rascat:Hyd
     rascat:rsr 7.1759e+00 ;
     rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Jun2016 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
     dcterms:title "London L&D Tailwater" ;
     rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
@@ -1813,7 +1813,7 @@ kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Jun2016 a rasca
     rascat:rsr 1.9255e-01 ;
     rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Nov2003 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
     dcterms:title "London L&D Tailwater" ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
@@ -1826,7 +1826,7 @@ kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Nov2003 a rasca
     rascat:rsr 2.3567e-01 ;
     rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
     dcterms:title "Marmet L&D Pool" ;
     rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
@@ -1839,7 +1839,7 @@ kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016 a rascat:Hyd
     rascat:rsr 7.485e-01 ;
     rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
     dcterms:title "Marmet L&D Pool" ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
@@ -1852,7 +1852,7 @@ kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003 a rascat:Hyd
     rascat:rsr 4.1071e-01 ;
     rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
     dcterms:title "Marmet L&D Tailwater" ;
     rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
@@ -1865,7 +1865,7 @@ kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 a rasca
     rascat:rsr 2.8112e-01 ;
     rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
     dcterms:title "Marmet L&D Tailwater" ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
@@ -1878,7 +1878,7 @@ kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 a rasca
     rascat:rsr 4.4465e-01 ;
     rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03165500 ;
@@ -1889,7 +1889,7 @@ kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 7.23e-01 ;
     rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03165500 ;
@@ -1900,7 +1900,7 @@ kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 4.8e-01 ;
     rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03168000 ;
@@ -1911,7 +1911,7 @@ kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 2.76e-01 ;
     rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-02T04:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03168000 ;
@@ -1922,7 +1922,7 @@ kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 8.34e-01 ;
     rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03168000 ;
@@ -1933,7 +1933,7 @@ kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.302e+00 ;
     rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03168000 ;
@@ -1944,7 +1944,7 @@ kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 5.55e-01 ;
     rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03161000 ;
@@ -1955,7 +1955,7 @@ kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 2.1e-01 ;
     rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03161000 ;
@@ -1966,7 +1966,7 @@ kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 4.8e-01 ;
     rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03161000 ;
@@ -1977,7 +1977,7 @@ kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.49e+00 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03161000 ;
@@ -1988,7 +1988,7 @@ kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 1.8e-01 ;
     rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03164000 ;
@@ -1999,7 +1999,7 @@ kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 3.4e-01 ;
     rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03164000 ;
@@ -2010,7 +2010,7 @@ kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 1.16e+00 ;
     rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03164000 ;
@@ -2021,7 +2021,7 @@ kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 2.87e+00 ;
     rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
 
-kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03164000 ;
@@ -2032,7 +2032,7 @@ kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 6.2e-01 ;
     rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 a rascat:Calibration ;
     dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1995" ;
     rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
@@ -2044,7 +2044,7 @@ kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 9.3227e-01 ;
     rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 a rascat:Calibration ;
     dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1996" ;
     rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
@@ -2056,7 +2056,7 @@ kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 6.8716e-01 ;
     rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 a rascat:Calibration ;
     dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in June 2016" ;
     rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
@@ -2068,7 +2068,7 @@ kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 1.9314e-01 ;
     rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 a rascat:Calibration ;
     dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in November 2003" ;
     rascat:endDateTime "2022-05-07T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
@@ -2080,7 +2080,7 @@ kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 a rascat:Hydrograph ;
     rascat:rsr 6.0257e-01 ;
     rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 a rascat:Hydrograph ;
+kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1995 ;
     rascat:fromStreamgage usgs_gages:03184000 ;
@@ -2091,7 +2091,7 @@ kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 a rascat:Hydrograph ;
     rascat:rsr 1.5856e+00 ;
     rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 a rascat:Hydrograph ;
+kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jan1996 ;
     rascat:fromStreamgage usgs_gages:03184000 ;
@@ -2102,7 +2102,7 @@ kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 a rascat:Hydrograph ;
     rascat:rsr 1.029e+00 ;
     rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 a rascat:Hydrograph ;
+kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Jun2016 ;
     rascat:fromStreamgage usgs_gages:03184000 ;
@@ -2113,7 +2113,7 @@ kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 a rascat:Hydrograph ;
     rascat:rsr 5.2275e-01 ;
     rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
 
-kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 a rascat:Hydrograph ;
+kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
     rascat:fromHydroEvent kanawha_events:Nov2003 ;
     rascat:fromStreamgage usgs_gages:03184000 ;
@@ -2187,7 +2187,7 @@ kanawha_models:BasinG6.p07 a rascat:RasPlan ;
 
 kanawha_models:BasinG6.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:BasinG6_03182888_Stage_Jun2016 ;
+    rascat:hasCalibration kanawha_calibration:BasinG6_03182888_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:BasinG6.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:BasinG6.u06 .
 
@@ -2197,25 +2197,25 @@ kanawha_models:BluestoneLocal.g01.terrain a rascat:Terrain ;
 
 kanawha_models:BluestoneLocal.p01 a rascat:RasPlan ;
     dcterms:title "JAN1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 ;
+    rascat:hasCalibration kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u01 .
 
 kanawha_models:BluestoneLocal.p02 a rascat:RasPlan ;
     dcterms:title "JAN1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 ;
+    rascat:hasCalibration kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u02 .
 
 kanawha_models:BluestoneLocal.p03 a rascat:RasPlan ;
     dcterms:title "NOV2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 ;
+    rascat:hasCalibration kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u03 .
 
 kanawha_models:BluestoneLocal.p04 a rascat:RasPlan ;
     dcterms:title "JUN2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016,
+    rascat:hasCalibration kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016,
         kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u04 .
@@ -2230,7 +2230,7 @@ kanawha_models:Bluestone_Upper.p15 a rascat:RasPlan ;
 Some  Breaklines and Terrain mods
 """ ;
     dcterms:title "Jan1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995,
+    rascat:hasCalibration kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995,
         kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
     rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u07 .
@@ -2241,7 +2241,7 @@ kanawha_models:Bluestone_Upper.p16 a rascat:RasPlan ;
 Somebreaklines and terrain mods
 """ ;
     dcterms:title "Jan1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996,
+    rascat:hasCalibration kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996,
         kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
     rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u08 .
@@ -2252,7 +2252,7 @@ kanawha_models:Bluestone_Upper.p17 a rascat:RasPlan ;
 100 ft stream refinement regions, 50 ft ref reg in towns
 Some Breaklines and terrain mods""" ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016,
+    rascat:hasCalibration kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016,
         kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
     rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u09 .
@@ -2263,7 +2263,7 @@ kanawha_models:Bluestone_Upper.p18 a rascat:RasPlan ;
 100ft stream refinement , 50ft ref  in towns
 Some breaklines and culvert terrain mods""" ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 ;
+    rascat:hasCalibration kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
     rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u06 .
 
@@ -2272,7 +2272,7 @@ kanawha_models:CoalRiver.g01.terrain a rascat:Terrain ;
 
 kanawha_models:CoalRiver.p01 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:CoalRiver_03198350_Flow_Nov2003,
+    rascat:hasCalibration kanawha_calibration:CoalRiver_03198350_Flow_Nov2003,
         kanawha_calibration:CoalRiver_03198500_Flow_Nov2003,
         kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
@@ -2280,21 +2280,21 @@ kanawha_models:CoalRiver.p01 a rascat:RasPlan ;
 
 kanawha_models:CoalRiver.p02 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:CoalRiver_03198500_Flow_Jan1995,
+    rascat:hasCalibration kanawha_calibration:CoalRiver_03198500_Flow_Jan1995,
         kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u02 .
 
 kanawha_models:CoalRiver.p03 a rascat:RasPlan ;
     dcterms:title "Jan1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:CoalRiver_03198500_Flow_Jan1996,
+    rascat:hasCalibration kanawha_calibration:CoalRiver_03198500_Flow_Jan1996,
         kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u03 .
 
 kanawha_models:CoalRiver.p04 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:CoalRiver_03198350_Flow_Jun2016,
+    rascat:hasCalibration kanawha_calibration:CoalRiver_03198350_Flow_Jun2016,
         kanawha_calibration:CoalRiver_03198500_Flow_Jun2016,
         kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
@@ -2314,7 +2314,7 @@ kanawha_models:ElkMiddle.g02.terrain a rascat:Terrain ;
 kanawha_models:ElkMiddle.p01 a rascat:RasPlan ;
     dcterms:description "November 2003.Calibrated to Queen Shoals Gage" ;
     dcterms:title "Unsteady_Mixed_Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003,
+    rascat:hasCalibration kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003,
         kanawha_calibration:ElkMiddle_03196800_Stage_Nov2003,
         kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003,
         kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 ;
@@ -2323,7 +2323,7 @@ kanawha_models:ElkMiddle.p01 a rascat:RasPlan ;
 
 kanawha_models:ElkMiddle.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jan1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996,
+    rascat:hasCalibration kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996,
         kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996,
         kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g02 ;
@@ -2331,7 +2331,7 @@ kanawha_models:ElkMiddle.p03 a rascat:RasPlan ;
 
 kanawha_models:ElkMiddle.p04 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016,
+    rascat:hasCalibration kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016,
         kanawha_calibration:ElkMiddle_03196600_Stage_Jun2016,
         kanawha_calibration:ElkMiddle_03196800_Flow_Jun2016,
         kanawha_calibration:ElkMiddle_03196800_Stage_Jun2016,
@@ -2342,7 +2342,7 @@ kanawha_models:ElkMiddle.p04 a rascat:RasPlan ;
 
 kanawha_models:ElkMiddle.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jan1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995,
+    rascat:hasCalibration kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995,
         kanawha_calibration:ElkMiddle_03196800_Stage_Jan1995,
         kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995,
         kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 ;
@@ -2428,7 +2428,7 @@ kanawha_models:GSummersville_B.g01.terrain a rascat:Terrain ;
 
 kanawha_models:GSummersville_B.p01 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996,
+    rascat:hasCalibration kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996,
         kanawha_calibration:GSummersville_B_03187500_Stage_Jan1996,
         kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996,
         kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 ;
@@ -2437,7 +2437,7 @@ kanawha_models:GSummersville_B.p01 a rascat:RasPlan ;
 
 kanawha_models:GSummersville_B.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003,
+    rascat:hasCalibration kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003,
         kanawha_calibration:GSummersville_B_03187000_Stage_Nov2003,
         kanawha_calibration:GSummersville_B_03187500_Flow_Nov2003,
         kanawha_calibration:GSummersville_B_03187500_Stage_Nov2003,
@@ -2449,7 +2449,7 @@ kanawha_models:GSummersville_B.p02 a rascat:RasPlan ;
 
 kanawha_models:GSummersville_B.p11 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016,
+    rascat:hasCalibration kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016,
         kanawha_calibration:GSummersville_B_03187000_Stage_Jun2016,
         kanawha_calibration:GSummersville_B_03187500_Flow_Jun2016,
         kanawha_calibration:GSummersville_B_03187500_Stage_Jun2016,
@@ -2462,7 +2462,7 @@ kanawha_models:GSummersville_B.p11 a rascat:RasPlan ;
 
 kanawha_models:GSummersville_B.p12 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995,
+    rascat:hasCalibration kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995,
         kanawha_calibration:GSummersville_B_03187500_Stage_Jan1995,
         kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995,
         kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 ;
@@ -2479,7 +2479,7 @@ kanawha_models:GSummersville_C.g01.terrain a rascat:Terrain ;
 
 kanawha_models:GSummersville_C.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003,
+    rascat:hasCalibration kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003,
         kanawha_calibration:GSummersville_C_03187000_Stage_Nov2003,
         kanawha_calibration:GSummersville_C_03187500_Flow_Nov2003,
         kanawha_calibration:GSummersville_C_03187500_Stage_Nov2003,
@@ -2491,7 +2491,7 @@ kanawha_models:GSummersville_C.p02 a rascat:RasPlan ;
 
 kanawha_models:GSummersville_C.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016,
+    rascat:hasCalibration kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016,
         kanawha_calibration:GSummersville_C_03187000_Stage_Jun2016,
         kanawha_calibration:GSummersville_C_03187500_Flow_Jun2016,
         kanawha_calibration:GSummersville_C_03187500_Stage_Jun2016,
@@ -2509,7 +2509,7 @@ kanawha_models:GSummersville_C.p04 a rascat:RasPlan ;
 
 kanawha_models:GSummersville_C.p05 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995,
+    rascat:hasCalibration kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995,
         kanawha_calibration:GSummersville_C_03187500_Stage_Jan1995,
         kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995,
         kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 ;
@@ -2523,7 +2523,7 @@ kanawha_models:GSummersville_C.p06 a rascat:RasPlan ;
 
 kanawha_models:GSummersville_C.p07 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996,
+    rascat:hasCalibration kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996,
         kanawha_calibration:GSummersville_C_03187500_Stage_Jan1996,
         kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996,
         kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 ;
@@ -2540,7 +2540,7 @@ kanawha_models:GauleyLower_BLE_FEM.g01.terrain a rascat:Terrain ;
 
 kanawha_models:GauleyLower_BLE_FEM.p01 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003,
+    rascat:hasCalibration kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003,
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003,
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
@@ -2548,14 +2548,14 @@ kanawha_models:GauleyLower_BLE_FEM.p01 a rascat:RasPlan ;
 
 kanawha_models:GauleyLower_BLE_FEM.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995,
+    rascat:hasCalibration kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995,
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u03 .
 
 kanawha_models:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016,
+    rascat:hasCalibration kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016,
         kanawha_calibration:GauleyLower_BLE_FEM_03190000_Stage_Jun2016,
         kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Jun2016,
         kanawha_calibration:GauleyLower_BLE_FEM_03191500_Stage_Jun2016,
@@ -2566,7 +2566,7 @@ kanawha_models:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
 
 kanawha_models:GauleyLower_BLE_FEM.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996,
+    rascat:hasCalibration kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996,
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u04 .
@@ -2661,25 +2661,25 @@ kanawha_models:Greenbrier_G8.p03 a rascat:RasPlan ;
 
 kanawha_models:Greenbrier_G8.p04 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 ;
+    rascat:hasCalibration kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u04 .
 
 kanawha_models:Greenbrier_G8.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 ;
+    rascat:hasCalibration kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u05 .
 
 kanawha_models:Greenbrier_G8.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 ;
+    rascat:hasCalibration kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u06 .
 
 kanawha_models:Greenbrier_G8.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 ;
+    rascat:hasCalibration kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u07 .
 
@@ -2736,25 +2736,25 @@ kanawha_models:Kanawha_G1.p04 a rascat:RasPlan ;
 
 kanawha_models:Kanawha_G1.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 ;
+    rascat:hasCalibration kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u05 .
 
 kanawha_models:Kanawha_G1.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 ;
+    rascat:hasCalibration kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u06 .
 
 kanawha_models:Kanawha_G1.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 ;
+    rascat:hasCalibration kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u07 .
 
 kanawha_models:Kanawha_G1.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 ;
+    rascat:hasCalibration kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u08 .
 
@@ -2832,7 +2832,7 @@ kanawha_models:New-LittleRiver.g01.terrain a rascat:Terrain ;
 
 kanawha_models:New-LittleRiver.p05 a rascat:RasPlan ;
     dcterms:title "JUN2016_HMS" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016,
+    rascat:hasCalibration kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016,
         kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u05 .
@@ -2846,14 +2846,14 @@ lower channel Manning's n
 shifted baseflow
 restart file""" ;
     dcterms:title "NOV2003_HMS" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003,
+    rascat:hasCalibration kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003,
         kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u08 .
 
 kanawha_models:New-LittleRiver.p07 a rascat:RasPlan ;
     dcterms:title "JAN1996_HMS" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996,
+    rascat:hasCalibration kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996,
         kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u07 .
@@ -2865,7 +2865,7 @@ kanawha_models:New-LittleRiver.p17 a rascat:RasPlan ;
 
 kanawha_models:New-LittleRiver.p19 a rascat:RasPlan ;
     dcterms:title "JAN1995_HMS" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995,
+    rascat:hasCalibration kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995,
         kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u10 .
@@ -2884,7 +2884,7 @@ kanawha_models:UpperKanawha.p01 a rascat:RasPlan ;
 Flow: June 2016 AORC gridded precipitation. Upstream inflow from USGS Kanawha Falls. Downstream time-stage translated to model outlet from USGS Charleston gage based on friction slope.
 Initial Conditions: Restart file from p.03""" ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016,
+    rascat:hasCalibration kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016,
         kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Jun2016,
         kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016,
         kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 ;
@@ -2896,7 +2896,7 @@ kanawha_models:UpperKanawha.p02 a rascat:RasPlan ;
 Flow: Nov 2003 AORC gridded precipitation. Upstream inflow from USGS Kanawha Falls. Downstream time-stage translated to model outlet from USGS Charleston gage based on friction slope.
 Initial Conditions: Restart file from p.04""" ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003,
+    rascat:hasCalibration kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003,
         kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Nov2003,
         kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003,
         kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 ;
@@ -2936,7 +2936,7 @@ kanawha_models:UpperNew_Lower.p01 a rascat:RasPlan ;
 
 kanawha_models:UpperNew_Lower.p02 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 ;
+    rascat:hasCalibration kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u02 .
 
@@ -2945,20 +2945,20 @@ kanawha_models:UpperNew_Lower.p03 a rascat:RasPlan ;
 
 Start time had to change from 07FEB1996 1200 to 02FEB1996 0400 due to a gap in the Upper New - Galax gage record.""" ;
     dcterms:title "Jan1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 ;
+    rascat:hasCalibration kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u03 .
 
 kanawha_models:UpperNew_Lower.p04 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003,
+    rascat:hasCalibration kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003,
         kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u04 .
 
 kanawha_models:UpperNew_Lower.p07 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016,
+    rascat:hasCalibration kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016,
         kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u05 .
@@ -2968,28 +2968,28 @@ kanawha_models:UpperNew_Upper.g01.terrain a rascat:Terrain ;
 
 kanawha_models:UpperNew_Upper.p01 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995,
+    rascat:hasCalibration kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995,
         kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u01 .
 
 kanawha_models:UpperNew_Upper.p02 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003,
+    rascat:hasCalibration kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003,
         kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u02 .
 
 kanawha_models:UpperNew_Upper.p03 a rascat:RasPlan ;
     dcterms:title "Jan1996" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996,
+    rascat:hasCalibration kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996,
         kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u03 .
 
 kanawha_models:UpperNew_Upper.p04 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016,
+    rascat:hasCalibration kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016,
         kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u04 .
@@ -3047,25 +3047,25 @@ kanawha_models:WatershedG3.p04 a rascat:RasPlan ;
 
 kanawha_models:WatershedG3.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 ;
+    rascat:hasCalibration kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u01 .
 
 kanawha_models:WatershedG3.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 ;
+    rascat:hasCalibration kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u02 .
 
 kanawha_models:WatershedG3.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 ;
+    rascat:hasCalibration kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u03 .
 
 kanawha_models:WatershedG3.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 ;
+    rascat:hasCalibration kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u04 .
 
@@ -3181,25 +3181,25 @@ kanawha_models:WatershedG9.p03 a rascat:RasPlan ;
 kanawha_models:WatershedG9.p04 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 ;
+    rascat:hasCalibration kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u04 .
 
 kanawha_models:WatershedG9.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 ;
+    rascat:hasCalibration kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g02 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01 .
 
 kanawha_models:WatershedG9.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 ;
+    rascat:hasCalibration kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g03 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u02 .
 
 kanawha_models:WatershedG9.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
-    rascat:hasCalibrationHydrograph kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 ;
+    rascat:hasCalibration kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
     rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u03 .
 
@@ -3213,84 +3213,87 @@ ffrd_orgs:Compass_JV a foaf:Organization ;
 
 ffrd_people:Andrew_Swynenberg a foaf:Person ;
     foaf:mbox "Andrew.Swynenberg@freese.com" ;
+    foaf:member ffrd_orgs:Freese ;
     foaf:name "Andrew Swynenberg" .
 
 ffrd_people:Britton_Wells a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "britton.wells@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Britton Wells" .
 
 ffrd_people:Courtney_Fournier a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "courtney.fournier@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "Courtney Fournier" .
 
 ffrd_people:Dawit_Zeweldi a foaf:Person ;
     foaf:mbox "Dawit.Zeweldi@freese.com" ;
+    foaf:member ffrd_orgs:Freese ;
     foaf:name "Dawit Zeweldi" .
 
 ffrd_people:Elizabeth_Vande_Krol a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "elizabeth.vandekrol@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "Elizabeth Vande Krol" .
 
 ffrd_people:John_Capobianco a foaf:Person ;
-    foaf:Organization ffrd_orgs:Baker ;
     foaf:mbox "John.Capobianco@mbakerintl.com" ;
+    foaf:member ffrd_orgs:Baker ;
     foaf:name "John Capobianco" .
 
 ffrd_people:Jon_Bartlotti a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "jonathan.bartlotti@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Jon Bartlotti" .
 
 ffrd_people:KC_Robinson a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "kc.robinson@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "KC Robinson" .
 
 ffrd_people:Kevan_Lee_Lum a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "kevan.leelum@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Kevan Lee Lum" .
 
 ffrd_people:Masoud_Meshkat a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "masoud.meshkat@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Masoud Meshkat" .
 
 ffrd_people:Matt_Lewis a foaf:Person ;
     foaf:mbox "Matt.Lewis@freese.com" ;
+    foaf:member ffrd_orgs:Freese ;
     foaf:name "Matt Lewis" .
 
 ffrd_people:Michelle_Terry a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "michelle.terry@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "Michelle Terry" .
 
 ffrd_people:Pete_Williams a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "pete.williams@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "Pete Williams" .
 
 ffrd_people:Ryan_Phol a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "ryan.pohl@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "Ryan Phol" .
 
 ffrd_people:Ryan_Pohl a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "ryan.pohl@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "Ryan Pohl" .
 
 ffrd_people:Sirui_Wen a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "sirui.wen@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Sirui Wen" .
 
 ffrd_people:Yacoub_Raheem a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "yacoub.raheem@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "Yacoub Raheem" .
 
 usgs_gages:03177120 a rascat:Streamgage ;
@@ -4215,23 +4218,23 @@ kanawha_models:WatershedG9.g03 a rascat:RasGeometry ;
     rascat:hasTerrain kanawha_models:WatershedG9.g03.terrain .
 
 ffrd_people:Daniyal_Siddiqui a foaf:Person ;
-    foaf:Organization ffrd_orgs:Baker ;
     foaf:mbox "daniyal.siddiqui@mbakerintl.com" ;
+    foaf:member ffrd_orgs:Baker ;
     foaf:name "Daniyal Siddiqui" .
 
 ffrd_people:Jonathan_Bartlotti a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "jonathan.bartlotti@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Jonathan Bartlotti" .
 
 ffrd_people:Julianna_Villa a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "julianna.villa@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Julianna Villa" .
 
 ffrd_people:Reuben_Cozmyer a foaf:Person ;
-    foaf:Organization ffrd_orgs:AECOM ;
     foaf:mbox "reuben.cozmyer@aecom.com" ;
+    foaf:member ffrd_orgs:AECOM ;
     foaf:name "Reuben Cozmyer" .
 
 usgs_gages:03165500 a rascat:Streamgage ;
@@ -4545,14 +4548,19 @@ kanawha_models:WatershedG9.u04 a rascat:RasUnsteadyFlow ;
             rascat:spatiallyVaried true ;
             rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
 
+ffrd_orgs:Freese a foaf:Organization ;
+    foaf:homepage <https://www.freese.com/> ;
+    foaf:member ffrd_orgs:ARC_JV ;
+    foaf:name "Freese and Nichols" .
+
 ffrd_people:Dami_George a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "dami.george@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Dami George" .
 
 ffrd_people:Mark_McBroom a foaf:Person ;
-    foaf:Organization ffrd_orgs:Baker ;
     foaf:mbox "mmcbroom@mbakerintl.com" ;
+    foaf:member ffrd_orgs:Baker ;
     foaf:name "Mark McBroom" .
 
 usgs_gages:03177710 a rascat:Streamgage ;
@@ -4689,12 +4697,9 @@ kanawha_models:WatershedG3.g02 a rascat:RasGeometry ;
             rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
     rascat:hasTerrain kanawha_models:WatershedG3.g02.terrain .
 
-ffrd_orgs:ARC_JV a foaf:Organization ;
-    foaf:name "ARC JV" .
-
 ffrd_orgs:Baker a foaf:Organization ;
-    foaf:Organization ffrd_orgs:ARC_JV ;
     foaf:homepage <https://mbakerintl.com/> ;
+    foaf:member ffrd_orgs:ARC_JV ;
     foaf:name "Michael Baker Intl" .
 
 usgs_gages:03161000 a rascat:Streamgage ;
@@ -4922,6 +4927,9 @@ kanawha_models:UpperNew_Upper.g01 a rascat:RasGeometry ;
             rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
     rascat:hasTerrain kanawha_models:UpperNew_Upper.g01.terrain .
 
+ffrd_orgs:ARC_JV a foaf:Organization ;
+    foaf:name "ARC JV" .
+
 usgs_gages:03196800 a rascat:Streamgage ;
     dcterms:identifier "03196800" ;
     dcterms:publisher "USGS" ;
@@ -5067,23 +5075,23 @@ usgs_gages:03192000 a rascat:Streamgage ;
     dcterms:title "Summersville Lake" .
 
 ffrd_orgs:AECOM a foaf:Organization ;
-    foaf:Organization ffrd_orgs:Compass_JV ;
     foaf:homepage <https://www.aecom.com/> ;
+    foaf:member ffrd_orgs:Compass_JV ;
     foaf:name "AECOM" .
 
 ffrd_people:Ben_Rufenacht a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "ben.rufenacht@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Ben Rufenacht" .
 
 ffrd_people:Josh_Hill a foaf:Person ;
-    foaf:Organization ffrd_orgs:WSP ;
     foaf:mbox "josh.hill@wsp.com" ;
+    foaf:member ffrd_orgs:WSP ;
     foaf:name "Josh Hill" .
 
 ffrd_orgs:WSP a foaf:Organization ;
-    foaf:Organization ffrd_orgs:ARC_JV ;
     foaf:homepage <https://www.wsp.com/> ;
+    foaf:member ffrd_orgs:ARC_JV ;
     foaf:name "WSP, Inc." .
 
 usgs_gages:03187500 a rascat:Streamgage ;

--- a/kanawha.ttl
+++ b/kanawha.ttl
@@ -7,6 +7,7 @@
 @prefix kanawha_misc: <http://example.ffrd.fema.gov/kanawha/misc/> .
 @prefix kanawha_models: <http://example.ffrd.fema.gov/kanawha/models/> .
 @prefix rascat: <http://www.example.org/rascat/0.1#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix usgs_gages: <https://waterdata.usgs.gov/monitoring-location/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
@@ -37,7 +38,8 @@ kanawha_models:BasinG6.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Pete_Williams ;
@@ -56,7 +58,8 @@ kanawha_models:BluestoneLocal.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.0" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:KC_Robinson,
@@ -76,7 +79,8 @@ kanawha_models:Bluestone_Upper.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Courtney_Fournier,
@@ -96,7 +100,8 @@ kanawha_models:CoalRiver.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Britton_Wells,
@@ -129,7 +134,8 @@ Version: Model Setup
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Ben_Rufenacht,
@@ -159,7 +165,8 @@ kanawha_models:G5.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Daniyal_Siddiqui,
@@ -179,7 +186,8 @@ kanawha_models:GSummersville_B.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Daniyal_Siddiqui,
@@ -201,7 +209,8 @@ kanawha_models:GSummersville_C.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:John_Capobianco,
@@ -220,7 +229,8 @@ kanawha_models:GauleyLower_BLE_FEM.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Ben_Rufenacht,
@@ -246,7 +256,8 @@ kanawha_models:Greenbrier_G7.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Ben_Rufenacht,
@@ -273,7 +284,8 @@ kanawha_models:Greenbrier_G8.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Ben_Rufenacht,
@@ -304,7 +316,8 @@ kanawha_models:Kanawha_G1.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Ben_Rufenacht,
@@ -335,7 +348,8 @@ kanawha_models:Kanawha_G2.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Reuben_Cozmyer,
@@ -357,7 +371,8 @@ kanawha_models:New-LittleRiver.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.0" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Andrew_Swynenberg,
@@ -387,7 +402,8 @@ Date: September 30, 2022""" ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Elizabeth_Vande_Krol,
@@ -409,7 +425,8 @@ kanawha_models:UpperNew_Lower.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Michelle_Terry ;
@@ -429,7 +446,8 @@ kanawha_models:UpperNew_Upper.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Ben_Rufenacht,
@@ -457,7 +475,8 @@ kanawha_models:WatershedG3.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Ben_Rufenacht,
@@ -483,7 +502,8 @@ kanawha_models:WatershedG4.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.prj a rascat:RasModel ;
     dcterms:creator ffrd_people:Ben_Rufenacht,
@@ -510,7 +530,8 @@ kanawha_models:WatershedG9.prj a rascat:RasModel ;
     rascat:projection kanawha_models:mmc_albers_ft.prj ;
     rascat:rasVersion "6.3.1" ;
     rascat:status "Final" ;
-    rascat:verticalDatum "NAVD88" .
+    rascat:verticalDatum "NAVD88" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:BasinG6_03182888_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2023-03-24T00:00:00"^^xsd:dateTime ;
@@ -521,7 +542,8 @@ kanawha_calibration:BasinG6_03182888_Stage_Jun2016 a rascat:Calibration ;
     rascat:pbias -1.1989e-01 ;
     rascat:r2 9.0879e-01 ;
     rascat:rsr 5.9411e-01 ;
-    rascat:startDateTime "2007-10-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2007-10-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
@@ -532,7 +554,8 @@ kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016 a rascat:Calibration ;
     rascat:pbias 2.0672e+01 ;
     rascat:r2 2.9e-01 ;
     rascat:rsr 1.14e+00 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-24T00:00:00"^^xsd:dateTime ;
@@ -543,7 +566,8 @@ kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 a rascat:Calibration ;
     rascat:pbias 2.53e-01 ;
     rascat:r2 9.46e-01 ;
     rascat:rsr 2.53e-01 ;
-    rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-30T00:00:00"^^xsd:dateTime ;
@@ -554,7 +578,8 @@ kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 a rascat:Calibration ;
     rascat:pbias -1.896e+00 ;
     rascat:r2 8.8e-01 ;
     rascat:rsr 3.6e-01 ;
-    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
@@ -565,7 +590,8 @@ kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 a rascat:Calibration ;
     rascat:pbias 3.555e+01 ;
     rascat:r2 1e-02 ;
     rascat:rsr 1.11e+00 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-27T00:00:00"^^xsd:dateTime ;
@@ -576,7 +602,8 @@ kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 a rascat:Calibration ;
     rascat:pbias 6.839e+00 ;
     rascat:r2 9.5e-01 ;
     rascat:rsr 2.3e-01 ;
-    rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
@@ -586,7 +613,8 @@ kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995 a rascat:Calibration 
     rascat:nse 5.6e-01 ;
     rascat:r2 6.2e-01 ;
     rascat:rsr 6.6e-01 ;
-    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
@@ -597,7 +625,8 @@ kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias 1.316e+01 ;
     rascat:r2 9.1e-01 ;
     rascat:rsr 3.3e-01 ;
-    rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
@@ -608,7 +637,8 @@ kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias 1.484e+01 ;
     rascat:r2 1e-02 ;
     rascat:rsr 1.09e+00 ;
-    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
@@ -618,7 +648,8 @@ kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 a rascat:Calibration 
     rascat:nse 8.4e-01 ;
     rascat:r2 8.8e-01 ;
     rascat:rsr 3.9e-01 ;
-    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
@@ -629,7 +660,8 @@ kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias 1.383e+01 ;
     rascat:r2 8.8e-01 ;
     rascat:rsr 4.2e-01 ;
-    rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
@@ -640,7 +672,8 @@ kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias 3.429e+01 ;
     rascat:r2 2.8e-01 ;
     rascat:rsr 9.9e-01 ;
-    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
@@ -650,7 +683,8 @@ kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 a rascat:Calibration 
     rascat:nse 9.3e-01 ;
     rascat:r2 9.4e-01 ;
     rascat:rsr 2.7e-01 ;
-    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03198350_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
@@ -661,7 +695,8 @@ kanawha_calibration:CoalRiver_03198350_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 2.513e+01 ;
     rascat:r2 7.3e-01 ;
     rascat:rsr 6.5e-01 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03198350_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
@@ -672,7 +707,8 @@ kanawha_calibration:CoalRiver_03198350_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 4.51e+00 ;
     rascat:r2 9e-01 ;
     rascat:rsr 3.2e-01 ;
-    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03198500_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
@@ -683,7 +719,8 @@ kanawha_calibration:CoalRiver_03198500_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias 3.598e+01 ;
     rascat:r2 2.3e-01 ;
     rascat:rsr 9.5e-01 ;
-    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03198500_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
@@ -694,7 +731,8 @@ kanawha_calibration:CoalRiver_03198500_Flow_Jan1996 a rascat:Calibration ;
     rascat:pbias -3.224e+01 ;
     rascat:r2 8e-02 ;
     rascat:rsr 1.67e+00 ;
-    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03198500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
@@ -705,7 +743,8 @@ kanawha_calibration:CoalRiver_03198500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 3.169e+01 ;
     rascat:r2 5e-01 ;
     rascat:rsr 8e-01 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03198500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
@@ -716,7 +755,8 @@ kanawha_calibration:CoalRiver_03198500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 1.206e+01 ;
     rascat:r2 8.6e-01 ;
     rascat:rsr 3.9e-01 ;
-    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
@@ -727,7 +767,8 @@ kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias 2.036e+01 ;
     rascat:r2 3.2e-01 ;
     rascat:rsr 8.4e-01 ;
-    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
@@ -738,7 +779,8 @@ kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 a rascat:Calibration ;
     rascat:pbias 8.02e+00 ;
     rascat:r2 7.3e-01 ;
     rascat:rsr 5.1e-01 ;
-    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
@@ -749,7 +791,8 @@ kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 3.821e+01 ;
     rascat:r2 2.7e-01 ;
     rascat:rsr 9.6e-01 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
@@ -760,7 +803,8 @@ kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 1.417e+01 ;
     rascat:r2 8.9e-01 ;
     rascat:rsr 3.6e-01 ;
-    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-01-06T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
@@ -771,7 +815,8 @@ kanawha_calibration:ElkMiddle_03196500_Stage_Jun2016 a rascat:Calibration ;
     rascat:pbias -6.8283e-02 ;
     rascat:r2 5.6463e-01 ;
     rascat:rsr 8.3896e-01 ;
-    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
@@ -782,7 +827,8 @@ kanawha_calibration:ElkMiddle_03196600_Stage_Jan1995 a rascat:Calibration ;
     rascat:pbias -1.1895e-01 ;
     rascat:r2 6.511e-01 ;
     rascat:rsr 1.3554e+00 ;
-    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
@@ -793,7 +839,8 @@ kanawha_calibration:ElkMiddle_03196600_Stage_Jan1996 a rascat:Calibration ;
     rascat:pbias 1.821e-01 ;
     rascat:r2 6.5615e-01 ;
     rascat:rsr 7.8902e-01 ;
-    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196600_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
@@ -804,7 +851,8 @@ kanawha_calibration:ElkMiddle_03196600_Stage_Jun2016 a rascat:Calibration ;
     rascat:pbias -2.8261e-01 ;
     rascat:r2 7.4283e-01 ;
     rascat:rsr 1.0997e+00 ;
-    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
@@ -815,7 +863,8 @@ kanawha_calibration:ElkMiddle_03196600_Stage_Nov2003 a rascat:Calibration ;
     rascat:pbias -1.6572e-01 ;
     rascat:r2 7.701e-01 ;
     rascat:rsr 8.2996e-01 ;
-    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196800_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
@@ -826,7 +875,8 @@ kanawha_calibration:ElkMiddle_03196800_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias -2.8881e+01 ;
     rascat:r2 9.1515e-01 ;
     rascat:rsr 6.2162e-01 ;
-    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196800_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
@@ -837,7 +887,8 @@ kanawha_calibration:ElkMiddle_03196800_Stage_Jan1995 a rascat:Calibration ;
     rascat:pbias -2.2115e-01 ;
     rascat:r2 6.714e-01 ;
     rascat:rsr 1.0726e+00 ;
-    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
@@ -848,7 +899,8 @@ kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996 a rascat:Calibration ;
     rascat:pbias 3.5148e-01 ;
     rascat:r2 6.1136e-01 ;
     rascat:rsr 8.4782e-01 ;
-    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196800_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
@@ -859,7 +911,8 @@ kanawha_calibration:ElkMiddle_03196800_Stage_Jun2016 a rascat:Calibration ;
     rascat:pbias -3.9992e-01 ;
     rascat:r2 8.5544e-01 ;
     rascat:rsr 6.2702e-01 ;
-    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03196800_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
@@ -870,7 +923,8 @@ kanawha_calibration:ElkMiddle_03196800_Stage_Nov2003 a rascat:Calibration ;
     rascat:pbias -1.3772e-01 ;
     rascat:r2 9.3277e-01 ;
     rascat:rsr 3.6328e-01 ;
-    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
@@ -881,7 +935,8 @@ kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias 7.7577e+00 ;
     rascat:r2 6.2639e-01 ;
     rascat:rsr 7.5204e-01 ;
-    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03197000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
@@ -892,7 +947,8 @@ kanawha_calibration:ElkMiddle_03197000_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias -1.8492e+00 ;
     rascat:r2 9.3743e-01 ;
     rascat:rsr 2.5266e-01 ;
-    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
@@ -903,7 +959,8 @@ kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 1.3164e+01 ;
     rascat:r2 9.2731e-01 ;
     rascat:rsr 3.0843e-01 ;
-    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-26T00:00:00"^^xsd:dateTime ;
@@ -914,7 +971,8 @@ kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 a rascat:Calibration ;
     rascat:pbias 2.1848e-01 ;
     rascat:r2 6.5966e-01 ;
     rascat:rsr 1.5419e+00 ;
-    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
@@ -925,7 +983,8 @@ kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 a rascat:Calibration ;
     rascat:pbias 7.8082e-01 ;
     rascat:r2 6.1415e-01 ;
     rascat:rsr 1.4724e+00 ;
-    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03197000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-06-30T00:00:00"^^xsd:dateTime ;
@@ -936,7 +995,8 @@ kanawha_calibration:ElkMiddle_03197000_Stage_Jun2016 a rascat:Calibration ;
     rascat:pbias 1.2879e-01 ;
     rascat:r2 8.1636e-01 ;
     rascat:rsr 4.7899e-01 ;
-    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-21T00:00:00"^^xsd:dateTime ;
@@ -947,7 +1007,8 @@ kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 a rascat:Calibration ;
     rascat:pbias 2.4529e-01 ;
     rascat:r2 9.0156e-01 ;
     rascat:rsr 5.1156e-01 ;
-    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-11T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
@@ -958,7 +1019,8 @@ kanawha_calibration:GSummersville_B_03186500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias -4.63e+00 ;
     rascat:r2 9.6e-01 ;
     rascat:rsr 1.9e-01 ;
-    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
@@ -969,7 +1031,8 @@ kanawha_calibration:GSummersville_B_03186500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 2.608e+01 ;
     rascat:r2 9.6e-01 ;
     rascat:rsr 3.7e-01 ;
-    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
@@ -980,7 +1043,8 @@ kanawha_calibration:GSummersville_B_03187000_Stage_Jan1995 a rascat:Calibration 
     rascat:pbias -8e-02 ;
     rascat:r2 7.6e-01 ;
     rascat:rsr 1.18e+00 ;
-    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
@@ -991,7 +1055,8 @@ kanawha_calibration:GSummersville_B_03187000_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias -1.7e-01 ;
     rascat:r2 6e-01 ;
     rascat:rsr 1.33e+00 ;
-    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
@@ -1002,7 +1067,8 @@ kanawha_calibration:GSummersville_B_03187000_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias -8e-02 ;
     rascat:r2 8.3e-01 ;
     rascat:rsr 5e-01 ;
-    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
@@ -1013,7 +1079,8 @@ kanawha_calibration:GSummersville_B_03187000_Stage_Nov2003 a rascat:Calibration 
     rascat:pbias -1.3e-01 ;
     rascat:r2 9.1e-01 ;
     rascat:rsr 7.5e-01 ;
-    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
@@ -1024,7 +1091,8 @@ kanawha_calibration:GSummersville_B_03187500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 1.2e+00 ;
     rascat:r2 8.7e-01 ;
     rascat:rsr 5.3e-01 ;
-    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
@@ -1035,7 +1103,8 @@ kanawha_calibration:GSummersville_B_03187500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 3.176e+01 ;
     rascat:r2 9.8e-01 ;
     rascat:rsr 2.2e-01 ;
-    rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187500_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1046,7 +1115,8 @@ kanawha_calibration:GSummersville_B_03187500_Stage_Jan1995 a rascat:Calibration 
     rascat:pbias -7e-02 ;
     rascat:r2 8.9e-01 ;
     rascat:rsr 2.03e+00 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187500_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1057,7 +1127,8 @@ kanawha_calibration:GSummersville_B_03187500_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias -1.2e-01 ;
     rascat:r2 7e-01 ;
     rascat:rsr 2.22e+00 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1068,7 +1139,8 @@ kanawha_calibration:GSummersville_B_03187500_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias -1e-01 ;
     rascat:r2 8.4e-01 ;
     rascat:rsr 1.53e+00 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03187500_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1079,7 +1151,8 @@ kanawha_calibration:GSummersville_B_03187500_Stage_Nov2003 a rascat:Calibration 
     rascat:pbias -7e-02 ;
     rascat:r2 9.1e-01 ;
     rascat:rsr 1.19e+00 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03188900_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
@@ -1090,7 +1163,8 @@ kanawha_calibration:GSummersville_B_03188900_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 1.609e+01 ;
     rascat:r2 9.2e-01 ;
     rascat:rsr 3e-01 ;
-    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03189100_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
@@ -1101,7 +1175,8 @@ kanawha_calibration:GSummersville_B_03189100_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias -5.06e+00 ;
     rascat:r2 9.6e-01 ;
     rascat:rsr 2e-01 ;
-    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03189100_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
@@ -1112,7 +1187,8 @@ kanawha_calibration:GSummersville_B_03189100_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 2.228e+01 ;
     rascat:r2 9e-01 ;
     rascat:rsr 3.5e-01 ;
-    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1123,7 +1199,8 @@ kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995 a rascat:Calibration 
     rascat:pbias 3e-02 ;
     rascat:r2 9.8e-01 ;
     rascat:rsr 3.4e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1134,7 +1211,8 @@ kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias -2e-01 ;
     rascat:r2 7.4e-01 ;
     rascat:rsr 6.4e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03189100_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1145,7 +1223,8 @@ kanawha_calibration:GSummersville_B_03189100_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias -1e-02 ;
     rascat:r2 9.1e-01 ;
     rascat:rsr 3.1e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_03189100_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1156,7 +1235,8 @@ kanawha_calibration:GSummersville_B_03189100_Stage_Nov2003 a rascat:Calibration 
     rascat:pbias 5e-02 ;
     rascat:r2 8.7e-01 ;
     rascat:rsr 4.8e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
@@ -1167,7 +1247,8 @@ kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 a rasc
     rascat:pbias -2.7e-01 ;
     rascat:r2 9.8e-01 ;
     rascat:rsr 1.05e+00 ;
-    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
@@ -1178,7 +1259,8 @@ kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 a rasc
     rascat:pbias 1.29e+00 ;
     rascat:r2 6.6e-01 ;
     rascat:rsr 1.02e+00 ;
-    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
@@ -1189,7 +1271,8 @@ kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jun2016 a rasc
     rascat:pbias -1.1e-01 ;
     rascat:r2 9.3e-01 ;
     rascat:rsr 3.4e-01 ;
-    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
@@ -1200,7 +1283,8 @@ kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Nov2003 a rasc
     rascat:pbias 1.181e+00 ;
     rascat:r2 6.07e-01 ;
     rascat:rsr 6.53e-01 ;
-    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T17:30:00"^^xsd:dateTime ;
@@ -1211,7 +1295,8 @@ kanawha_calibration:GSummersville_C_03186500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 1.403e+01 ;
     rascat:r2 9.4e-01 ;
     rascat:rsr 2.5e-01 ;
-    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
@@ -1222,7 +1307,8 @@ kanawha_calibration:GSummersville_C_03186500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 3.256e+01 ;
     rascat:r2 9.5e-01 ;
     rascat:rsr 3.5e-01 ;
-    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
@@ -1233,7 +1319,8 @@ kanawha_calibration:GSummersville_C_03187000_Stage_Jan1995 a rascat:Calibration 
     rascat:pbias 6e-02 ;
     rascat:r2 5.7e-01 ;
     rascat:rsr 1e+00 ;
-    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
@@ -1244,7 +1331,8 @@ kanawha_calibration:GSummersville_C_03187000_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias -6e-02 ;
     rascat:r2 6.6e-01 ;
     rascat:rsr 7.1e-01 ;
-    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
@@ -1255,7 +1343,8 @@ kanawha_calibration:GSummersville_C_03187000_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias 5e-02 ;
     rascat:r2 7.4e-01 ;
     rascat:rsr 5.4e-01 ;
-    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T23:00:00"^^xsd:dateTime ;
@@ -1266,7 +1355,8 @@ kanawha_calibration:GSummersville_C_03187000_Stage_Nov2003 a rascat:Calibration 
     rascat:pbias 1e-02 ;
     rascat:r2 9.2e-01 ;
     rascat:rsr 2.9e-01 ;
-    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
@@ -1277,7 +1367,8 @@ kanawha_calibration:GSummersville_C_03187500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 1.755e+01 ;
     rascat:r2 8.2e-01 ;
     rascat:rsr 5.2e-01 ;
-    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T21:00:00"^^xsd:dateTime ;
@@ -1288,7 +1379,8 @@ kanawha_calibration:GSummersville_C_03187500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 5.039e+01 ;
     rascat:r2 8.8e-01 ;
     rascat:rsr 4.5e-01 ;
-    rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-10-01T01:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187500_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1299,7 +1391,8 @@ kanawha_calibration:GSummersville_C_03187500_Stage_Jan1995 a rascat:Calibration 
     rascat:pbias -3e-02 ;
     rascat:r2 7.3e-01 ;
     rascat:rsr 1.01e+00 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187500_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1310,7 +1403,8 @@ kanawha_calibration:GSummersville_C_03187500_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias -8e-02 ;
     rascat:r2 7e-01 ;
     rascat:rsr 1.59e+00 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1321,7 +1415,8 @@ kanawha_calibration:GSummersville_C_03187500_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias -6e-02 ;
     rascat:r2 7.7e-01 ;
     rascat:rsr 1e+00 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03187500_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1332,7 +1427,8 @@ kanawha_calibration:GSummersville_C_03187500_Stage_Nov2003 a rascat:Calibration 
     rascat:pbias -2e-02 ;
     rascat:r2 8.9e-01 ;
     rascat:rsr 5.9e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03188900_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T21:45:00"^^xsd:dateTime ;
@@ -1343,7 +1439,8 @@ kanawha_calibration:GSummersville_C_03188900_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 1.599e+01 ;
     rascat:r2 8.9e-01 ;
     rascat:rsr 3.4e-01 ;
-    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-05-01T00:15:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03189100_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T17:45:00"^^xsd:dateTime ;
@@ -1354,7 +1451,8 @@ kanawha_calibration:GSummersville_C_03189100_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 1.849e+01 ;
     rascat:r2 9.3e-01 ;
     rascat:rsr 2.9e-01 ;
-    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-04-30T18:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03189100_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T22:00:00"^^xsd:dateTime ;
@@ -1365,7 +1463,8 @@ kanawha_calibration:GSummersville_C_03189100_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 4.14e+01 ;
     rascat:r2 8.8e-01 ;
     rascat:rsr 4.4e-01 ;
-    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-10-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1376,7 +1475,8 @@ kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995 a rascat:Calibration 
     rascat:pbias 3e-02 ;
     rascat:r2 7.7e-01 ;
     rascat:rsr 7.1e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1387,7 +1487,8 @@ kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias -4e-02 ;
     rascat:r2 7.3e-01 ;
     rascat:rsr 6.7e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03189100_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1398,7 +1499,8 @@ kanawha_calibration:GSummersville_C_03189100_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias 1e-02 ;
     rascat:r2 8.6e-01 ;
     rascat:rsr 4.1e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_03189100_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T22:30:00"^^xsd:dateTime ;
@@ -1409,7 +1511,8 @@ kanawha_calibration:GSummersville_C_03189100_Stage_Nov2003 a rascat:Calibration 
     rascat:pbias 5e-02 ;
     rascat:r2 8.6e-01 ;
     rascat:rsr 5.3e-01 ;
-    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:30:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
@@ -1420,7 +1523,8 @@ kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 a rasc
     rascat:pbias 4.1e-01 ;
     rascat:r2 8.2e-01 ;
     rascat:rsr 1.86e+00 ;
-    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
@@ -1431,7 +1535,8 @@ kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 a rasc
     rascat:pbias 1.4e+00 ;
     rascat:r2 6.4e-01 ;
     rascat:rsr 1.1e+00 ;
-    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
@@ -1442,7 +1547,8 @@ kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jun2016 a rasc
     rascat:pbias 2.8e-01 ;
     rascat:r2 9.9e-01 ;
     rascat:rsr 3.5e-01 ;
-    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2021-12-31T11:00:00"^^xsd:dateTime ;
@@ -1453,7 +1559,8 @@ kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Nov2003 a rasc
     rascat:pbias 3e-02 ;
     rascat:r2 9e-01 ;
     rascat:rsr 3.5e-01 ;
-    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1985-01-01T11:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
@@ -1464,7 +1571,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03190000_Flow_Jun2016 a rascat:Calibrati
     rascat:pbias -1.1652e+01 ;
     rascat:r2 8.78e-01 ;
     rascat:rsr 3.76e-01 ;
-    rascat:startDateTime "2012-08-30T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2012-08-30T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03190000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1475,7 +1583,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03190000_Stage_Jun2016 a rascat:Calibrat
     rascat:pbias -7.4e-02 ;
     rascat:r2 9.53e-01 ;
     rascat:rsr 2.959e-01 ;
-    rascat:startDateTime "2014-04-02T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2014-04-02T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1486,7 +1595,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Jun2016 a rascat:Calibrati
     rascat:pbias 1.26e+01 ;
     rascat:r2 6.7e-01 ;
     rascat:rsr 5.77e-01 ;
-    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1497,7 +1607,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03191500_Flow_Nov2003 a rascat:Calibrati
     rascat:pbias 1.181e+00 ;
     rascat:r2 6.07e-01 ;
     rascat:rsr 6.53e-01 ;
-    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03191500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1508,7 +1619,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03191500_Stage_Jun2016 a rascat:Calibrat
     rascat:pbias 3.1e-02 ;
     rascat:r2 8.96e-01 ;
     rascat:rsr 5.56e-01 ;
-    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2009-08-31T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
@@ -1519,7 +1631,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995 a rascat:Calibrati
     rascat:pbias -1.5726e+00 ;
     rascat:r2 9.62e-01 ;
     rascat:rsr 2.18e-01 ;
-    rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
@@ -1530,7 +1643,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996 a rascat:Calibrati
     rascat:pbias 2.4806e+01 ;
     rascat:r2 7.85e-01 ;
     rascat:rsr 5.93e-01 ;
-    rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1928-10-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-31T00:00:00"^^xsd:dateTime ;
@@ -1541,7 +1655,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jun2016 a rascat:Calibrati
     rascat:pbias 1.5e+00 ;
     rascat:r2 9.18e-01 ;
     rascat:rsr 2.95e-01 ;
-    rascat:startDateTime "2016-04-30T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-04-30T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-31T00:00:00"^^xsd:dateTime ;
@@ -1552,7 +1667,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003 a rascat:Calibrati
     rascat:pbias 1.6551e+01 ;
     rascat:r2 6.66e-01 ;
     rascat:rsr 6.38e-01 ;
-    rascat:startDateTime "2003-09-30T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-09-30T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1563,7 +1679,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 a rascat:Calibrat
     rascat:pbias -1.95e-01 ;
     rascat:r2 9.59e-01 ;
     rascat:rsr 7.15e-01 ;
-    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1574,7 +1691,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 a rascat:Calibrat
     rascat:pbias -9.6e-02 ;
     rascat:r2 8.75e-01 ;
     rascat:rsr 4.15e-01 ;
-    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1585,7 +1703,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jun2016 a rascat:Calibrat
     rascat:pbias -2.01e-01 ;
     rascat:r2 8.76e-01 ;
     rascat:rsr 4.67e-01 ;
-    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-09-01T00:00:00"^^xsd:dateTime ;
@@ -1596,7 +1715,8 @@ kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 a rascat:Calibrat
     rascat:pbias -1.82e-01 ;
     rascat:r2 7.84e-01 ;
     rascat:rsr 6.12e-01 ;
-    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1994-12-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
@@ -1607,7 +1727,8 @@ kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 a rascat:Calibration ;
     rascat:pbias 4.089e+01 ;
     rascat:r2 4.2492e-01 ;
     rascat:rsr 1.6907e+00 ;
-    rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2022-01-01T00:00:00"^^xsd:dateTime ;
@@ -1618,7 +1739,8 @@ kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 a rascat:Calibration ;
     rascat:pbias 5.867e+01 ;
     rascat:r2 5.4692e-01 ;
     rascat:rsr 1.3993e+00 ;
-    rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1900-01-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
@@ -1629,7 +1751,8 @@ kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 a rascat:Calibration ;
     rascat:pbias 2.2797e+01 ;
     rascat:r2 9.0781e-01 ;
     rascat:rsr 3.7249e-01 ;
-    rascat:startDateTime "2016-04-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-04-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-12-01T00:00:00"^^xsd:dateTime ;
@@ -1640,7 +1763,8 @@ kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 a rascat:Calibration ;
     rascat:pbias 3.0033e+01 ;
     rascat:r2 9.363e-01 ;
     rascat:rsr 4.9232e-01 ;
-    rascat:startDateTime "2003-09-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-09-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
@@ -1651,7 +1775,8 @@ kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias 3.2361e+01 ;
     rascat:r2 8.9384e-01 ;
     rascat:rsr 1.0849e+00 ;
-    rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2022-06-26T00:00:00"^^xsd:dateTime ;
@@ -1662,7 +1787,8 @@ kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 a rascat:Calibration ;
     rascat:pbias 2.2303e+01 ;
     rascat:r2 9.242e-01 ;
     rascat:rsr 7.5269e-01 ;
-    rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1943-04-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1673,7 +1799,8 @@ kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 2.6618e+01 ;
     rascat:r2 7.3227e-01 ;
     rascat:rsr 7.3549e-01 ;
-    rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2016-08-01T00:00:00"^^xsd:dateTime ;
@@ -1684,7 +1811,8 @@ kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 3.1036e+01 ;
     rascat:r2 8.1655e-01 ;
     rascat:rsr 8.2889e-01 ;
-    rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-10-01T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
@@ -1695,7 +1823,8 @@ kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995 a rascat:Calibration 
     rascat:pbias -5.96e+00 ;
     rascat:r2 9.6e-01 ;
     rascat:rsr 2.2e-01 ;
-    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
@@ -1706,7 +1835,8 @@ kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias -2.86e+00 ;
     rascat:r2 9.5e-01 ;
     rascat:rsr 3.2e-01 ;
-    rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
@@ -1717,7 +1847,8 @@ kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias 1.411e+01 ;
     rascat:r2 6.4e-01 ;
     rascat:rsr 8.1e-01 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
@@ -1728,7 +1859,8 @@ kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003 a rascat:Calibration 
     rascat:pbias 5.13e+00 ;
     rascat:r2 9.4e-01 ;
     rascat:rsr 2.5e-01 ;
-    rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
@@ -1739,7 +1871,8 @@ kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 a rascat:Calibration 
     rascat:pbias 9.25e+00 ;
     rascat:r2 5.8e-01 ;
     rascat:rsr 6.5e-01 ;
-    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
@@ -1750,7 +1883,8 @@ kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 a rascat:Calibration 
     rascat:pbias 1.31e+00 ;
     rascat:r2 5.6e-01 ;
     rascat:rsr 6.6e-01 ;
-    rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
@@ -1761,7 +1895,8 @@ kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 a rascat:Calibration 
     rascat:pbias 1.955e+01 ;
     rascat:r2 1e-02 ;
     rascat:rsr 1.14e+00 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
@@ -1772,7 +1907,8 @@ kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 a rascat:Calibration 
     rascat:pbias 9.42e+00 ;
     rascat:r2 3.9e-01 ;
     rascat:rsr 7.9e-01 ;
-    rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
@@ -1785,7 +1921,8 @@ kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Jun2016 a rascat:Cal
     rascat:pbias -2.696e-01 ;
     rascat:r2 7.9179e-03 ;
     rascat:rsr 1.348e+01 ;
-    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE. Pool hydrograph provided remained flat during event and was disregarded from calibration." ;
@@ -1798,7 +1935,8 @@ kanawha_calibration:UpperKanawha_USACE_London_LD_Pool_Stage_Nov2003 a rascat:Cal
     rascat:pbias -1.8653e-01 ;
     rascat:r2 2.2156e-01 ;
     rascat:rsr 7.1759e+00 ;
-    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Jun2016 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
@@ -1811,7 +1949,8 @@ kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Jun2016 a rasca
     rascat:pbias -1.3638e-01 ;
     rascat:r2 9.8229e-01 ;
     rascat:rsr 1.9255e-01 ;
-    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Nov2003 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
@@ -1824,7 +1963,8 @@ kanawha_calibration:UpperKanawha_USACE_London_LD_Tailwater_Stage_Nov2003 a rasca
     rascat:pbias -1.4871e-01 ;
     rascat:r2 9.8069e-01 ;
     rascat:rsr 2.3567e-01 ;
-    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
@@ -1837,7 +1977,8 @@ kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016 a rascat:Cal
     rascat:pbias 7.278e-02 ;
     rascat:r2 5.7783e-01 ;
     rascat:rsr 7.485e-01 ;
-    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
@@ -1850,7 +1991,8 @@ kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003 a rascat:Cal
     rascat:pbias 2.3509e-02 ;
     rascat:r2 9.2922e-01 ;
     rascat:rsr 4.1071e-01 ;
-    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
@@ -1863,7 +2005,8 @@ kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 a rasca
     rascat:pbias 1.2004e-01 ;
     rascat:r2 9.2979e-01 ;
     rascat:rsr 2.8112e-01 ;
-    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 a rascat:Calibration ;
     dcterms:description "Stage hydrograph provided by USACE." ;
@@ -1876,7 +2019,8 @@ kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 a rasca
     rascat:pbias 6.1883e-02 ;
     rascat:r2 8.096e-01 ;
     rascat:rsr 4.4465e-01 ;
-    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
@@ -1887,7 +2031,8 @@ kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 4.2e-01 ;
     rascat:r2 7.23e-01 ;
     rascat:rsr 7.23e-01 ;
-    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
@@ -1898,7 +2043,8 @@ kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 7.498e+00 ;
     rascat:r2 9.35e-01 ;
     rascat:rsr 4.8e-01 ;
-    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
@@ -1909,7 +2055,8 @@ kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias 3.959e+00 ;
     rascat:r2 9.78e-01 ;
     rascat:rsr 2.76e-01 ;
-    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-02-02T04:00:00"^^xsd:dateTime ;
@@ -1920,7 +2067,8 @@ kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 a rascat:Calibration ;
     rascat:pbias 9.689e+00 ;
     rascat:r2 3.26e-01 ;
     rascat:rsr 8.34e-01 ;
-    rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
@@ -1931,7 +2079,8 @@ kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 5.316e+00 ;
     rascat:r2 4.9e-02 ;
     rascat:rsr 1.302e+00 ;
-    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
@@ -1942,7 +2091,8 @@ kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 2.6041e+01 ;
     rascat:r2 9.84e-01 ;
     rascat:rsr 5.55e-01 ;
-    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
@@ -1953,7 +2103,8 @@ kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias -5.26e+00 ;
     rascat:r2 9.7e-01 ;
     rascat:rsr 2.1e-01 ;
-    rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
@@ -1964,7 +2115,8 @@ kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996 a rascat:Calibration ;
     rascat:pbias -2.61e+00 ;
     rascat:r2 7.9e-01 ;
     rascat:rsr 4.8e-01 ;
-    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
@@ -1975,7 +2127,8 @@ kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias -8.08e+00 ;
     rascat:r2 2e-02 ;
     rascat:rsr 1.49e+00 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
@@ -1986,7 +2139,8 @@ kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias -7.82e+00 ;
     rascat:r2 9.7e-01 ;
     rascat:rsr 1.8e-01 ;
-    rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
@@ -1997,7 +2151,8 @@ kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias 2.077e+01 ;
     rascat:r2 9.1e-01 ;
     rascat:rsr 3.4e-01 ;
-    rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
@@ -2008,7 +2163,8 @@ kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 a rascat:Calibration ;
     rascat:pbias 5.675e+01 ;
     rascat:r2 3.3e-01 ;
     rascat:rsr 1.16e+00 ;
-    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
@@ -2019,7 +2175,8 @@ kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 5.876e+01 ;
     rascat:r2 1.4e-01 ;
     rascat:rsr 2.87e+00 ;
-    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
@@ -2030,7 +2187,8 @@ kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 4.4e+01 ;
     rascat:r2 8e-01 ;
     rascat:rsr 6.2e-01 ;
-    rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 a rascat:Calibration ;
     dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1995" ;
@@ -2042,7 +2200,8 @@ kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias 3.516e+01 ;
     rascat:r2 6.1693e-01 ;
     rascat:rsr 9.3227e-01 ;
-    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 a rascat:Calibration ;
     dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in January 1996" ;
@@ -2054,7 +2213,8 @@ kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 a rascat:Calibration ;
     rascat:pbias 3.5098e+01 ;
     rascat:r2 9.1635e-01 ;
     rascat:rsr 6.8716e-01 ;
-    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 a rascat:Calibration ;
     dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in June 2016" ;
@@ -2066,7 +2226,8 @@ kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 1.3292e+01 ;
     rascat:r2 9.8257e-01 ;
     rascat:rsr 1.9314e-01 ;
-    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 a rascat:Calibration ;
     dcterms:description "Flooding at the Greenbrier River gage at Buckey, WV in November 2003" ;
@@ -2078,7 +2239,8 @@ kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 4.5403e+01 ;
     rascat:r2 9.099e-01 ;
     rascat:rsr 6.0257e-01 ;
-    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1930-11-18T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 a rascat:Calibration ;
     rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
@@ -2089,7 +2251,8 @@ kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 a rascat:Calibration ;
     rascat:pbias 4.5535e+01 ;
     rascat:r2 9.0313e-01 ;
     rascat:rsr 1.5856e+00 ;
-    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 a rascat:Calibration ;
     rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
@@ -2100,7 +2263,8 @@ kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 a rascat:Calibration ;
     rascat:pbias 6.035e+01 ;
     rascat:r2 8.3038e-01 ;
     rascat:rsr 1.029e+00 ;
-    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 a rascat:Calibration ;
     rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
@@ -2111,7 +2275,8 @@ kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 a rascat:Calibration ;
     rascat:pbias 2.8095e+01 ;
     rascat:r2 9.4184e-01 ;
     rascat:rsr 5.2275e-01 ;
-    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 a rascat:Calibration ;
     rascat:endDateTime "2022-02-05T00:00:00"^^xsd:dateTime ;
@@ -2122,107 +2287,202 @@ kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 a rascat:Calibration ;
     rascat:pbias 2.8095e+01 ;
     rascat:r2 9.4184e-01 ;
     rascat:rsr 5.2275e-01 ;
-    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1936-03-18T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:BasinG6.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:BasinG6.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 228618 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:BasinG6.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:BasinG6.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:BasinG6.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:BasinG6.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:BasinG6.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 228618 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:BasinG6.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:BasinG6.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:BasinG6.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:BasinG6.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:BasinG6.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 228618 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:BasinG6.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:BasinG6.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:BasinG6.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:BasinG6.p01 a rascat:RasPlan ;
     dcterms:description "Plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:BasinG6.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.p02 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:BasinG6.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.p03 a rascat:RasPlan ;
     dcterms:description "Plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:BasinG6.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.p04 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:BasinG6.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasGeometry kanawha_models:BasinG6.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasGeometry kanawha_models:BasinG6.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasGeometry kanawha_models:BasinG6.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasCalibration kanawha_calibration:BasinG6_03182888_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:BasinG6.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:BasinG6.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:BluestoneLocal.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 100 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 417852 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 50 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:BluestoneLocal.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:BluestoneLocal.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ] .
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:BluestoneLocal.p01 a rascat:RasPlan ;
     dcterms:title "JAN1995" ;
     rascat:hasCalibration kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.p02 a rascat:RasPlan ;
     dcterms:title "JAN1996" ;
     rascat:hasCalibration kanawha_calibration:BluestoneLocal_03179800_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.p03 a rascat:RasPlan ;
     dcterms:title "NOV2003" ;
     rascat:hasCalibration kanawha_calibration:BluestoneLocal_03179800_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.p04 a rascat:RasPlan ;
     dcterms:title "JUN2016" ;
     rascat:hasCalibration kanawha_calibration:BluestoneLocal_03177120_Stage_Jun2016,
         kanawha_calibration:BluestoneLocal_03179800_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:BluestoneLocal.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:BluestoneLocal.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Bluestone_Upper.g07.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 400 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 318361 ;
+    rascat:nominalCellSize 400 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Bluestone_Upper.g07.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Bluestone_Upper.g07.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.g07.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and dam/berm embankments. LiDAR-processed DEM was hydroflattened by provider." ] .
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and dam/berm embankments. LiDAR-processed DEM was hydroflattened by provider." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:Bluestone_Upper.p15 a rascat:RasPlan ;
     dcterms:description """Jan 5-29, 1995 (UTC) using excess precip from Corps HMS model plus baseflow
@@ -2233,7 +2493,8 @@ Some  Breaklines and Terrain mods
     rascat:hasCalibration kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1995,
         kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
-    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.p16 a rascat:RasPlan ;
     dcterms:description """14 Jan - 6 Feb 1996 (UTC) excess precip from HMS plus baseflow
@@ -2244,7 +2505,8 @@ Somebreaklines and terrain mods
     rascat:hasCalibration kanawha_calibration:Bluestone_Upper_03177710_Stage_Jan1996,
         kanawha_calibration:Bluestone_Upper_03179000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
-    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u08 .
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u08 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.p17 a rascat:RasPlan ;
     dcterms:description """Jun 20 - Jul 3, 2016 (UTC) using Excess Precipitation from Corps HMS model plus baseflow
@@ -2255,7 +2517,8 @@ Some Breaklines and terrain mods""" ;
     rascat:hasCalibration kanawha_calibration:Bluestone_Upper_03177710_Stage_Jun2016,
         kanawha_calibration:Bluestone_Upper_03179000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
-    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u09 .
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u09 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.p18 a rascat:RasPlan ;
     dcterms:description """Nov 6-24, 2003 (UTC) using Excess Precip from calibrated HEC-HMS model from Corps (2km cells) and Baseflow
@@ -2265,7 +2528,25 @@ Some breaklines and culvert terrain mods""" ;
     dcterms:title "Nov2003" ;
     rascat:hasCalibration kanawha_calibration:Bluestone_Upper_03179000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:Bluestone_Upper.g07 ;
-    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:Bluestone_Upper.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:CoalRiver.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 500 ;
+    rascat:breaklinesMinCellSize 100 ;
+    rascat:cellCount 332739 ;
+    rascat:nominalCellSize 500 ;
+    rascat:refinementRegionsMaxCellSize 50 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:CoalRiver.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:CoalRiver.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> .
@@ -2276,21 +2557,24 @@ kanawha_models:CoalRiver.p01 a rascat:RasPlan ;
         kanawha_calibration:CoalRiver_03198500_Flow_Nov2003,
         kanawha_calibration:CoalRiver_03200500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.p02 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
     rascat:hasCalibration kanawha_calibration:CoalRiver_03198500_Flow_Jan1995,
         kanawha_calibration:CoalRiver_03200500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.p03 a rascat:RasPlan ;
     dcterms:title "Jan1996" ;
     rascat:hasCalibration kanawha_calibration:CoalRiver_03198500_Flow_Jan1996,
         kanawha_calibration:CoalRiver_03200500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.p04 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
@@ -2298,15 +2582,52 @@ kanawha_models:CoalRiver.p04 a rascat:RasPlan ;
         kanawha_calibration:CoalRiver_03198500_Flow_Jun2016,
         kanawha_calibration:CoalRiver_03200500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:CoalRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:CoalRiver.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from existing CWMS 1D HEC-RAS model. Channel raster developed and mosaiced to DEM and then incorporated into model" .
+    dcterms:description "Channel data pulled from existing CWMS 1D HEC-RAS model. Channel raster developed and mosaiced to DEM and then incorporated into model" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:ElkMiddle.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 100 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 761035 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 150 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:ElkMiddle.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:ElkMiddle.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
     rascat:hasBathymetry kanawha_models:ElkMiddle.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments. Hydroflattened major rivers" ] .
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments. Hydroflattened major rivers" ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
+
+kanawha_models:ElkMiddle.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 100 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 761035 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 150 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:ElkMiddle.g02.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:ElkMiddle.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> .
@@ -2319,7 +2640,8 @@ kanawha_models:ElkMiddle.p01 a rascat:RasPlan ;
         kanawha_calibration:ElkMiddle_03197000_Flow_Nov2003,
         kanawha_calibration:ElkMiddle_03197000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jan1996" ;
@@ -2327,7 +2649,8 @@ kanawha_models:ElkMiddle.p03 a rascat:RasPlan ;
         kanawha_calibration:ElkMiddle_03196800_Stage_Jan1996,
         kanawha_calibration:ElkMiddle_03197000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.p04 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jun2016" ;
@@ -2338,7 +2661,8 @@ kanawha_models:ElkMiddle.p04 a rascat:RasPlan ;
         kanawha_calibration:ElkMiddle_03197000_Flow_Jun2016,
         kanawha_calibration:ElkMiddle_03197000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_Mixed_Jan1995" ;
@@ -2347,84 +2671,159 @@ kanawha_models:ElkMiddle.p06 a rascat:RasPlan ;
         kanawha_calibration:ElkMiddle_03197000_Flow_Jan1995,
         kanawha_calibration:ElkMiddle_03197000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:ElkMiddle.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:ElkMiddle.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:G5.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:G5.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 230930 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:G5.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:G5.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:G5.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:G5.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:G5.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 230930 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:G5.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:G5.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:G5.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:G5.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:G5.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 230930 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:G5.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:G5.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:G5.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:G5.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:G5.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:G5.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:G5.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:G5.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:G5.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:G5.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.p05 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:G5.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:G5.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:G5.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.p06 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:G5.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:G5.u09 .
+    rascat:hasUnsteadyFlow kanawha_models:G5.u09 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.p11 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasGeometry kanawha_models:G5.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:G5.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:G5.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.p12 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasGeometry kanawha_models:G5.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:G5.u11 .
+    rascat:hasUnsteadyFlow kanawha_models:G5.u11 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.p13 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasGeometry kanawha_models:G5.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:G5.u08 .
+    rascat:hasUnsteadyFlow kanawha_models:G5.u08 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.p14 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasGeometry kanawha_models:G5.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:G5.u10 .
+    rascat:hasUnsteadyFlow kanawha_models:G5.u10 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.u05 a rascat:RasUnsteadyFlow ;
-    dcterms:title "Jan-1996 Initial Conditions" .
+    dcterms:title "Jan-1996 Initial Conditions" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." .
+    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:GSummersville_B.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 587360 ;
+    rascat:nominalCellSize 500 ;
+    rascat:refinementRegionsMaxCellSize 200 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:GSummersville_B.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:GSummersville_B.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
     rascat:hasBathymetry kanawha_models:GSummersville_B.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] .
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:GSummersville_B.p01 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
@@ -2433,7 +2832,8 @@ kanawha_models:GSummersville_B.p01 a rascat:RasPlan ;
         kanawha_calibration:GSummersville_B_03189100_Stage_Jan1996,
         kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
@@ -2445,7 +2845,8 @@ kanawha_models:GSummersville_B.p02 a rascat:RasPlan ;
         kanawha_calibration:GSummersville_B_03189100_Stage_Nov2003,
         kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.p11 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
@@ -2458,7 +2859,8 @@ kanawha_models:GSummersville_B.p11 a rascat:RasPlan ;
         kanawha_calibration:GSummersville_B_03189100_Stage_Jun2016,
         kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.p12 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
@@ -2467,15 +2869,35 @@ kanawha_models:GSummersville_B.p12 a rascat:RasPlan ;
         kanawha_calibration:GSummersville_B_03189100_Stage_Jan1995,
         kanawha_calibration:GSummersville_B_USACE_Summersville_Lake_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:GSummersville_B.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_B.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." .
+    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:GSummersville_C.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 954995 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 200 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:GSummersville_C.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover kanawha_misc:baker_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:GSummersville_C.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:baker_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
     rascat:hasBathymetry kanawha_models:GSummersville_C.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] .
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:GSummersville_C.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
@@ -2487,7 +2909,8 @@ kanawha_models:GSummersville_C.p02 a rascat:RasPlan ;
         kanawha_calibration:GSummersville_C_03189100_Stage_Nov2003,
         kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
@@ -2500,12 +2923,14 @@ kanawha_models:GSummersville_C.p03 a rascat:RasPlan ;
         kanawha_calibration:GSummersville_C_03189100_Stage_Jun2016,
         kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.p04 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003-RF" ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.p05 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
@@ -2514,12 +2939,14 @@ kanawha_models:GSummersville_C.p05 a rascat:RasPlan ;
         kanawha_calibration:GSummersville_C_03189100_Stage_Jan1995,
         kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995-RF" ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.p07 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
@@ -2528,15 +2955,35 @@ kanawha_models:GSummersville_C.p07 a rascat:RasPlan ;
         kanawha_calibration:GSummersville_C_03189100_Stage_Jan1996,
         kanawha_calibration:GSummersville_C_USACE_Summersville_Lake_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:GSummersville_C.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:GSummersville_C.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." .
+    dcterms:description "Channel data assumed from USGS rating curves at gages 03189100 & 03186500. Summersville Lake pulled from 2003 Sedimentation Survey provided by USACE." ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:GauleyLower_BLE_FEM.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 1088388 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 50 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:GauleyLower_BLE_FEM.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover kanawha_misc:baker_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:GauleyLower_BLE_FEM.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:baker_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
     rascat:hasBathymetry kanawha_models:GauleyLower_BLE_FEM.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ] .
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road and dam/berm embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:GauleyLower_BLE_FEM.p01 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Nov2003" ;
@@ -2544,14 +2991,16 @@ kanawha_models:GauleyLower_BLE_FEM.p01 a rascat:RasPlan ;
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Nov2003,
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.p02 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1995" ;
     rascat:hasCalibration kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1995,
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jun2016" ;
@@ -2562,280 +3011,512 @@ kanawha_models:GauleyLower_BLE_FEM.p03 a rascat:RasPlan ;
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jun2016,
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.p06 a rascat:RasPlan ;
     dcterms:title "Unsteady_MultiHazard_Jan1996" ;
     rascat:hasCalibration kanawha_calibration:GauleyLower_BLE_FEM_03192000_Flow_Jan1996,
         kanawha_calibration:GauleyLower_BLE_FEM_03192000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:GauleyLower_BLE_FEM.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:GauleyLower_BLE_FEM.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:Greenbrier_G7.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Greenbrier_G7.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 100 ;
+    rascat:cellCount 250141 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Greenbrier_G7.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Greenbrier_G7.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Greenbrier_G7.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:Greenbrier_G7.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Greenbrier_G7.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 100 ;
+    rascat:cellCount 250141 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Greenbrier_G7.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Greenbrier_G7.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Greenbrier_G7.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:Greenbrier_G7.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Greenbrier_G7.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 100 ;
+    rascat:cellCount 250141 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Greenbrier_G7.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Greenbrier_G7.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Greenbrier_G7.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:Greenbrier_G7.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G7.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.p03 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G7.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.p04 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G7.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G7.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G7.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G7.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G7.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:Greenbrier_G8.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Greenbrier_G8.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 100 ;
+    rascat:cellCount 291713 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Greenbrier_G8.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Greenbrier_G8.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Greenbrier_G8.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:Greenbrier_G8.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Greenbrier_G8.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 100 ;
+    rascat:cellCount 291713 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Greenbrier_G8.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Greenbrier_G8.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Greenbrier_G8.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:Greenbrier_G8.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Greenbrier_G8.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 100 ;
+    rascat:cellCount 291713 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Greenbrier_G8.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Greenbrier_G8.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Greenbrier_G8.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:Greenbrier_G8.p01 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.p03 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.p04 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasCalibration kanawha_calibration:Greenbrier_G8_03183500_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasCalibration kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasCalibration kanawha_calibration:Greenbrier_G8_03183500_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasCalibration kanawha_calibration:Greenbrier_G8_03183500_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:Greenbrier_G8.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:Greenbrier_G8.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.u02 a rascat:RasUnsteadyFlow ;
-    dcterms:title "JAN1996" .
+    dcterms:title "JAN1996" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:Kanawha_G1.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Kanawha_G1.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 206812 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Kanawha_G1.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Kanawha_G1.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Kanawha_G1.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:Kanawha_G1.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Kanawha_G1.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 206812 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Kanawha_G1.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Kanawha_G1.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Kanawha_G1.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:Kanawha_G1.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Kanawha_G1.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 206812 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Kanawha_G1.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Kanawha_G1.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Kanawha_G1.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:Kanawha_G1.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.p02 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.p03 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasCalibration kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasCalibration kanawha_calibration:Kanawha_G1_03180500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasCalibration kanawha_calibration:Kanawha_G1_03180500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasCalibration kanawha_calibration:Kanawha_G1_03180500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:Kanawha_G1.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u08 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G1.u08 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:Kanawha_G2.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Kanawha_G2.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 318146 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Kanawha_G2.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Kanawha_G2.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Kanawha_G2.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:Kanawha_G2.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Kanawha_G2.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 318146 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Kanawha_G2.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Kanawha_G2.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Kanawha_G2.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:Kanawha_G2.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:Kanawha_G2.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 318146 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:Kanawha_G2.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:Kanawha_G2.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:Kanawha_G2.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:Kanawha_G2.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.p02 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.p03 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u06 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u06 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasGeometry kanawha_models:Kanawha_G2.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u08 .
+    rascat:hasUnsteadyFlow kanawha_models:Kanawha_G2.u08 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:New-LittleRiver.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 100 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 517580 ;
+    rascat:nominalCellSize 200 .
+
+kanawha_models:New-LittleRiver.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:New-LittleRiver.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ] .
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments and other terrain features that artificially block flow." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:New-LittleRiver.p05 a rascat:RasPlan ;
     dcterms:title "JUN2016_HMS" ;
     rascat:hasCalibration kanawha_calibration:New-LittleRiver_03170000_Stage_Jun2016,
         kanawha_calibration:New-LittleRiver_03171000_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.p06 a rascat:RasPlan ;
     dcterms:description """with rating curve at dam and initial condition
@@ -2849,35 +3530,63 @@ restart file""" ;
     rascat:hasCalibration kanawha_calibration:New-LittleRiver_03170000_Stage_Nov2003,
         kanawha_calibration:New-LittleRiver_03171000_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u08 .
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u08 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.p07 a rascat:RasPlan ;
     dcterms:title "JAN1996_HMS" ;
     rascat:hasCalibration kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1996,
         kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1996 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.p17 a rascat:RasPlan ;
     dcterms:title "restart_file" ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u09 .
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u09 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.p19 a rascat:RasPlan ;
     dcterms:title "JAN1995_HMS" ;
     rascat:hasCalibration kanawha_calibration:New-LittleRiver_03170000_Stage_Jan1995,
         kanawha_calibration:New-LittleRiver_03171000_Stage_Jan1995 ;
     rascat:hasGeometry kanawha_models:New-LittleRiver.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u10 .
+    rascat:hasUnsteadyFlow kanawha_models:New-LittleRiver.u10 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.g01.bathymetry a rascat:Bathymetry ;
     dcterms:description "Channel data merged into base LiDAR through GIS mosaic process" ;
-    dcterms:title "USACE Kanawaha CWMS Model" .
+    dcterms:title "USACE Kanawaha CWMS Model" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:UpperKanawha.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 537254 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 50 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:UpperKanawha.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:UpperKanawha.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:UpperKanawha.g01.structures a rascat:Structures ;
+    dcterms:description "London/Marmet L&D Structures and Gate operations copied from USACE CWMS Model" ;
+    dcterms:title "USACE Kanawaha CWMS Model" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
     rascat:hasBathymetry kanawha_models:UpperKanawha.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments, and to create connectivity for major culvert systems in populated areas" ] .
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments, and to create connectivity for major culvert systems in populated areas" ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:UpperKanawha.p01 a rascat:RasPlan ;
     dcterms:description """Geometry: Upper Kanawha BLE geometry. Includes Marmet and London L&D. Gate operations from Kanawha CWMS. 
@@ -2889,7 +3598,8 @@ Initial Conditions: Restart file from p.03""" ;
         kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Jun2016,
         kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Jun2016 ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u11 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u11 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.p02 a rascat:RasPlan ;
     dcterms:description """Geometry: Upper Kanawha BLE geometry. Includes Marmet and London L&D. Gate operations from Kanawha CWMS. 
@@ -2901,17 +3611,20 @@ Initial Conditions: Restart file from p.04""" ;
         kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Pool_Stage_Nov2003,
         kanawha_calibration:UpperKanawha_USACE_Marmet_LD_Tailwater_Stage_Nov2003 ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u08 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u08 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.p03 a rascat:RasPlan ;
     dcterms:title "Jun2016_InitialConditions" ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u09 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u09 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.p04 a rascat:RasPlan ;
     dcterms:title "Nov2003_InitialConditions" ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u07 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u07 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.p05 a rascat:RasPlan ;
     dcterms:description """Geometry: Upper Kanawha BLE geometry. Includes Marmet and London L&D. Gate operations from Kanawha CWMS. 
@@ -2919,12 +3632,35 @@ Flow: Jan 1996 AORC gridded precipitation. Upstream inflow from USGS Kanawha Fal
 Initial Conditions: Restart file from p.06""" ;
     dcterms:title "Jan1996" ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.p06 a rascat:RasPlan ;
     dcterms:title "Jan1996_InitialConditions" ;
     rascat:hasGeometry kanawha_models:UpperKanawha.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperKanawha.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:UpperNew_Lower.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 200 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 800701 ;
+    rascat:nominalCellSize 1000 .
+
+kanawha_models:UpperNew_Lower.g03.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:UpperNew_Lower.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:UpperNew_Lower.g03.structures a rascat:Structures ;
+    dcterms:description "Description of hydraulic data and water surface elevations of the dam was used to create a rating curve" ;
+    dcterms:relation <http://claytorhydro.com/lib/docs/ClaytorWaterManagementPlanJune2009asapprovedbyFERCDec2011.pdf>,
+        <https://hydroreform.org/wp-content/uploads/2020/09/New-River-Virginia-Final.pdf> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> .
@@ -2932,13 +3668,15 @@ kanawha_models:UpperNew_Lower.g03.terrain a rascat:Terrain ;
 kanawha_models:UpperNew_Lower.p01 a rascat:RasPlan ;
     dcterms:title "Restart" ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.p02 a rascat:RasPlan ;
     dcterms:title "Jan1995" ;
     rascat:hasCalibration kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.p03 a rascat:RasPlan ;
     dcterms:description """Start time had to change from 14JAN1996 1200 to 19JAN1996 0500 due to a gap in the Upper New - Galax gage record.
@@ -2947,21 +3685,41 @@ Start time had to change from 07FEB1996 1200 to 02FEB1996 0400 due to a gap in t
     dcterms:title "Jan1996" ;
     rascat:hasCalibration kanawha_calibration:UpperNew_Lower_03168000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.p04 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
     rascat:hasCalibration kanawha_calibration:UpperNew_Lower_03165500_Flow_Nov2003,
         kanawha_calibration:UpperNew_Lower_03168000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.p07 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
     rascat:hasCalibration kanawha_calibration:UpperNew_Lower_03165500_Flow_Jun2016,
         kanawha_calibration:UpperNew_Lower_03168000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:UpperNew_Lower.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Lower.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:UpperNew_Upper.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 100 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 1064723 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 50 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:UpperNew_Upper.g01.precip_losses a rascat:PrecipLosses ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:UpperNew_Upper.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> .
@@ -2971,327 +3729,529 @@ kanawha_models:UpperNew_Upper.p01 a rascat:RasPlan ;
     rascat:hasCalibration kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1995,
         kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.p02 a rascat:RasPlan ;
     dcterms:title "Nov2003" ;
     rascat:hasCalibration kanawha_calibration:UpperNew_Upper_03161000_Flow_Nov2003,
         kanawha_calibration:UpperNew_Upper_03164000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.p03 a rascat:RasPlan ;
     dcterms:title "Jan1996" ;
     rascat:hasCalibration kanawha_calibration:UpperNew_Upper_03161000_Flow_Jan1996,
         kanawha_calibration:UpperNew_Upper_03164000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.p04 a rascat:RasPlan ;
     dcterms:title "Jun2016" ;
     rascat:hasCalibration kanawha_calibration:UpperNew_Upper_03161000_Flow_Jun2016,
         kanawha_calibration:UpperNew_Upper_03164000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:UpperNew_Upper.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:UpperNew_Upper.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.u05 a rascat:RasUnsteadyFlow ;
-    dcterms:title "RestartFile" .
+    dcterms:title "RestartFile" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:WatershedG3.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG3.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 411065 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG3.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG3.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG3.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:WatershedG3.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG3.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 411065 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG3.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG3.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG3.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:WatershedG3.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG3.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 411065 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG3.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG3.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG3.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:WatershedG3.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u05 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u05 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.p02 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG3.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.p03 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG3.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG3.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasCalibration kanawha_calibration:WatershedG3_03182500_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasCalibration kanawha_calibration:WatershedG3_03182500_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasCalibration kanawha_calibration:WatershedG3_03182500_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasCalibration kanawha_calibration:WatershedG3_03182500_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:WatershedG3.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG3.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:WatershedG4.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG4.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 319443 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG4.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG4.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG4.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:WatershedG4.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG4.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 319443 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG4.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG4.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG4.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:WatershedG4.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG4.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 319443 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG4.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG4.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG4.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:WatershedG4.p01 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.p02 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.p03 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.p04 a rascat:RasPlan ;
     dcterms:description "This plan was not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasGeometry kanawha_models:WatershedG4.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasGeometry kanawha_models:WatershedG4.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasGeometry kanawha_models:WatershedG4.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasGeometry kanawha_models:WatershedG4.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG4.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-kanawha_models:WatershedG9.g01.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG9.g01.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 273560 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG9.g01.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 2003 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG9.g01.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.g01.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG9.g01.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:WatershedG9.g02.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG9.g02.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 273560 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG9.g02.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG9.g02.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.g02.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG9.g02.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
-kanawha_models:WatershedG9.g03.bathymetry a rascat:Bathymetry ;
-    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area." .
+kanawha_models:WatershedG9.g03.mesh2d a rascat:Mesh2D ;
+    rascat:breaklinesMaxCellSize 50 ;
+    rascat:breaklinesMinCellSize 50 ;
+    rascat:cellCount 273560 ;
+    rascat:nominalCellSize 200 ;
+    rascat:refinementRegionsMaxCellSize 100 ;
+    rascat:refinementRegionsMinCellSize 50 .
+
+kanawha_models:WatershedG9.g03.precip_losses a rascat:PrecipLosses ;
+    dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_models:WatershedG9.g03.roughness a rascat:Roughness ;
+    rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.g03.terrain a rascat:Terrain ;
     rascat:dem <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> ;
-    rascat:hasBathymetry kanawha_models:WatershedG9.g03.bathymetry ;
-    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ] .
+    rascat:hasBathymetry kanawha_misc:greenbrier_riskmap_bathymetry ;
+    rascat:hasTerrainModifications [ dcterms:description "Cuts made through road embankments." ;
+            rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ] .
 
 kanawha_models:WatershedG9.p01 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Jan-1995 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.p02 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.p03 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Nov-2003 Initial Conditions" ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.p04 a rascat:RasPlan ;
     dcterms:description "This plan is not utilized" ;
     dcterms:title "Jun-2016 Initial Conditions" ;
     rascat:hasCalibration kanawha_calibration:WatershedG9_03184000_Flow_Jun2016 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.p05 a rascat:RasPlan ;
     dcterms:title "Jan-1995 Calibration" ;
     rascat:hasCalibration kanawha_calibration:WatershedG9_03184000_Flow_Jan1995 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u01 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.p06 a rascat:RasPlan ;
     dcterms:title "Jan-1996 Calibration" ;
     rascat:hasCalibration kanawha_calibration:WatershedG9_03184000_Flow_Jan1996 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g03 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u02 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u02 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.p07 a rascat:RasPlan ;
     dcterms:title "Nov-2003 Calibration" ;
     rascat:hasCalibration kanawha_calibration:WatershedG9_03184000_Flow_Nov2003 ;
     rascat:hasGeometry kanawha_models:WatershedG9.g01 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u03 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u03 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.p08 a rascat:RasPlan ;
     dcterms:title "Jun-2016 Calibration" ;
     rascat:hasGeometry kanawha_models:WatershedG9.g02 ;
-    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u04 .
+    rascat:hasUnsteadyFlow kanawha_models:WatershedG9.u04 ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
-ffrd_orgs:Compass_JV a foaf:Organization ;
-    foaf:name "Compass JV" .
+ffrd_orgs:Compass_PTS_JV a foaf:Organization ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
+    foaf:name "Compass PTS JV" .
+
+ffrd_orgs:Dewberry a foaf:Organization ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
+    foaf:homepage <https://www.dewberry.com/> ;
+    foaf:member ffrd_orgs:STARR_II ;
+    foaf:name "Dewberry" .
+
+ffrd_orgs:STARR_II a foaf:Organization ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
+    foaf:homepage <https://starr-team.com/> ;
+    foaf:name "STARR II" .
 
 ffrd_people:Andrew_Swynenberg a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "Andrew.Swynenberg@freese.com" ;
     foaf:member ffrd_orgs:Freese ;
     foaf:name "Andrew Swynenberg" .
 
 ffrd_people:Britton_Wells a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "britton.wells@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Britton Wells" .
 
 ffrd_people:Courtney_Fournier a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "courtney.fournier@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "Courtney Fournier" .
 
 ffrd_people:Dawit_Zeweldi a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "Dawit.Zeweldi@freese.com" ;
     foaf:member ffrd_orgs:Freese ;
     foaf:name "Dawit Zeweldi" .
 
 ffrd_people:Elizabeth_Vande_Krol a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "elizabeth.vandekrol@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "Elizabeth Vande Krol" .
 
 ffrd_people:John_Capobianco a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "John.Capobianco@mbakerintl.com" ;
     foaf:member ffrd_orgs:Baker ;
     foaf:name "John Capobianco" .
 
 ffrd_people:Jon_Bartlotti a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "jonathan.bartlotti@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Jon Bartlotti" .
 
 ffrd_people:KC_Robinson a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "kc.robinson@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "KC Robinson" .
 
 ffrd_people:Kevan_Lee_Lum a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "kevan.leelum@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Kevan Lee Lum" .
 
 ffrd_people:Masoud_Meshkat a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "masoud.meshkat@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Masoud Meshkat" .
 
 ffrd_people:Matt_Lewis a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "Matt.Lewis@freese.com" ;
     foaf:member ffrd_orgs:Freese ;
     foaf:name "Matt Lewis" .
 
 ffrd_people:Michelle_Terry a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "michelle.terry@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "Michelle Terry" .
 
 ffrd_people:Pete_Williams a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "pete.williams@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "Pete Williams" .
 
 ffrd_people:Ryan_Phol a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "ryan.pohl@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "Ryan Phol" .
 
 ffrd_people:Ryan_Pohl a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "ryan.pohl@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "Ryan Pohl" .
 
+ffrd_people:Seth_Lawler a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
+    foaf:mbox "slawler@dewberry.com" ;
+    foaf:member ffrd_orgs:Dewberry ;
+    foaf:name "Seth Lawler" .
+
 ffrd_people:Sirui_Wen a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "sirui.wen@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Sirui Wen" .
 
 ffrd_people:Yacoub_Raheem a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "yacoub.raheem@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "Yacoub Raheem" .
@@ -3313,18 +4273,11 @@ usgs_gages:03196500 a rascat:Streamgage ;
 
 kanawha_models:BasinG6.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G6_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 228618 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:BasinG6.g03.terrain .
+    rascat:hasMesh2D kanawha_models:BasinG6.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:BasinG6.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:BasinG6.g03.roughness ;
+    rascat:hasTerrain kanawha_models:BasinG6.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Inital Conditions" ;
@@ -3333,7 +4286,8 @@ kanawha_models:BasinG6.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
@@ -3342,7 +4296,8 @@ kanawha_models:BasinG6.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Initial Conditions" ;
@@ -3351,7 +4306,8 @@ kanawha_models:BasinG6.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Calibration" ;
@@ -3360,7 +4316,8 @@ kanawha_models:BasinG6.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Calibration" ;
@@ -3369,7 +4326,8 @@ kanawha_models:BasinG6.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Calibration" ;
@@ -3378,7 +4336,8 @@ kanawha_models:BasinG6.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995" ;
@@ -3387,7 +4346,8 @@ kanawha_models:BluestoneLocal.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-24T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-12T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996" ;
@@ -3396,7 +4356,8 @@ kanawha_models:BluestoneLocal.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-01-30T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003" ;
@@ -3405,7 +4366,8 @@ kanawha_models:BluestoneLocal.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-27T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-07T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "JUN2016" ;
@@ -3414,7 +4376,8 @@ kanawha_models:BluestoneLocal.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003_ExessPrecip_Baseflow" ;
@@ -3423,7 +4386,8 @@ kanawha_models:Bluestone_Upper.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1995_ExcessPrecip_Baseflow" ;
@@ -3432,7 +4396,8 @@ kanawha_models:Bluestone_Upper.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996_ExcessPrecip_Baseflow" ;
@@ -3441,7 +4406,8 @@ kanawha_models:Bluestone_Upper.u08 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-06T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.u09 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016_ExcessPrecip_Baseflow" ;
@@ -3450,7 +4416,8 @@ kanawha_models:Bluestone_Upper.u09 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-03T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003" ;
@@ -3459,7 +4426,8 @@ kanawha_models:CoalRiver.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1995" ;
@@ -3468,7 +4436,8 @@ kanawha_models:CoalRiver.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996" ;
@@ -3477,7 +4446,8 @@ kanawha_models:CoalRiver.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-01T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016" ;
@@ -3486,23 +4456,16 @@ kanawha_models:CoalRiver.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.g02 a rascat:RasGeometry ;
     dcterms:title "ElkMiddle_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 100 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 761035 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 150 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:ElkMiddle.g02.terrain .
+    rascat:hasMesh2D kanawha_models:ElkMiddle.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:ElkMiddle.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:ElkMiddle.g02.roughness ;
+    rascat:hasTerrain kanawha_models:ElkMiddle.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Nov2003" ;
@@ -3511,7 +4474,8 @@ kanawha_models:ElkMiddle.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Jan1995" ;
@@ -3520,7 +4484,8 @@ kanawha_models:ElkMiddle.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Jan1996" ;
@@ -3529,7 +4494,8 @@ kanawha_models:ElkMiddle.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "ElkMiddle_Jun2016" ;
@@ -3538,22 +4504,16 @@ kanawha_models:ElkMiddle.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G5_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 230930 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:G5.g03.terrain .
+    rascat:hasMesh2D kanawha_models:G5.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:G5.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:G5.g03.roughness ;
+    rascat:hasTerrain kanawha_models:G5.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
@@ -3562,7 +4522,8 @@ kanawha_models:G5.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Initial Conditions" ;
@@ -3571,7 +4532,8 @@ kanawha_models:G5.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Calibration" ;
@@ -3580,7 +4542,8 @@ kanawha_models:G5.u08 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.u09 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Initial Conditions" ;
@@ -3589,7 +4552,8 @@ kanawha_models:G5.u09 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.u10 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Calibration" ;
@@ -3598,7 +4562,8 @@ kanawha_models:G5.u10 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.u11 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Calibration" ;
@@ -3607,7 +4572,8 @@ kanawha_models:G5.u11 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Nov2003" ;
@@ -3616,7 +4582,8 @@ kanawha_models:GSummersville_B.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jan1995" ;
@@ -3625,7 +4592,8 @@ kanawha_models:GSummersville_B.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jan1996" ;
@@ -3634,7 +4602,8 @@ kanawha_models:GSummersville_B.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T10:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jun2016" ;
@@ -3643,7 +4612,8 @@ kanawha_models:GSummersville_B.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jun2016" ;
@@ -3652,7 +4622,8 @@ kanawha_models:GSummersville_C.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jan1996" ;
@@ -3661,7 +4632,8 @@ kanawha_models:GSummersville_C.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T10:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleyLower_Floodplain_Nov2003" ;
@@ -3670,7 +4642,8 @@ kanawha_models:GauleyLower_BLE_FEM.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleyLower_Floodplain_Jun2016" ;
@@ -3679,7 +4652,8 @@ kanawha_models:GauleyLower_BLE_FEM.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleyLower_FloodPlain_Jan1995" ;
@@ -3688,7 +4662,8 @@ kanawha_models:GauleyLower_BLE_FEM.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-23T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleyLower_FloodPlain_Jan1996" ;
@@ -3697,22 +4672,16 @@ kanawha_models:GauleyLower_BLE_FEM.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-01-22T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G7_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 100 ;
-            rascat:cellCount 250141 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Greenbrier_G7.g03.terrain .
+    rascat:hasMesh2D kanawha_models:Greenbrier_G7.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Greenbrier_G7.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:Greenbrier_G7.g03.roughness ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G7.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 IC" ;
@@ -3721,7 +4690,8 @@ kanawha_models:Greenbrier_G7.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003 IC" ;
@@ -3730,7 +4700,8 @@ kanawha_models:Greenbrier_G7.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "JUN2016 Cal" ;
@@ -3739,7 +4710,8 @@ kanawha_models:Greenbrier_G7.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 Cal" ;
@@ -3748,7 +4720,8 @@ kanawha_models:Greenbrier_G7.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996 Cal" ;
@@ -3757,7 +4730,8 @@ kanawha_models:Greenbrier_G7.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003 Cal" ;
@@ -3766,22 +4740,16 @@ kanawha_models:Greenbrier_G7.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G8_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 100 ;
-            rascat:cellCount 291713 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Greenbrier_G8.g03.terrain .
+    rascat:hasMesh2D kanawha_models:Greenbrier_G8.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Greenbrier_G8.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:Greenbrier_G8.g03.roughness ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G8.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 IC" ;
@@ -3790,7 +4758,8 @@ kanawha_models:Greenbrier_G8.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003 IC" ;
@@ -3799,7 +4768,8 @@ kanawha_models:Greenbrier_G8.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "JUN2016 Calibration" ;
@@ -3808,7 +4778,8 @@ kanawha_models:Greenbrier_G8.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995 Cal" ;
@@ -3817,7 +4788,8 @@ kanawha_models:Greenbrier_G8.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996 Cal" ;
@@ -3826,7 +4798,8 @@ kanawha_models:Greenbrier_G8.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003 Cal" ;
@@ -3835,7 +4808,8 @@ kanawha_models:Greenbrier_G8.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Initial Conditions" ;
@@ -3844,7 +4818,8 @@ kanawha_models:Kanawha_G1.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Initial Conditions" ;
@@ -3853,7 +4828,8 @@ kanawha_models:Kanawha_G1.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Initial Conditions" ;
@@ -3862,7 +4838,8 @@ kanawha_models:Kanawha_G1.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Initial Conditions" ;
@@ -3871,7 +4848,8 @@ kanawha_models:Kanawha_G1.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
@@ -3880,7 +4858,8 @@ kanawha_models:Kanawha_G1.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Calibration" ;
@@ -3889,7 +4868,8 @@ kanawha_models:Kanawha_G1.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Calibration" ;
@@ -3898,7 +4878,8 @@ kanawha_models:Kanawha_G1.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Calibration" ;
@@ -3907,22 +4888,16 @@ kanawha_models:Kanawha_G1.u08 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G2_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 318146 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Kanawha_G2.g03.terrain .
+    rascat:hasMesh2D kanawha_models:Kanawha_G2.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Kanawha_G2.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:Kanawha_G2.g03.roughness ;
+    rascat:hasTerrain kanawha_models:Kanawha_G2.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Initial Conditions" ;
@@ -3931,7 +4906,8 @@ kanawha_models:Kanawha_G2.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Initial Conditions" ;
@@ -3940,7 +4916,8 @@ kanawha_models:Kanawha_G2.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Initial Conditions" ;
@@ -3949,7 +4926,8 @@ kanawha_models:Kanawha_G2.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Initial Conditions" ;
@@ -3958,7 +4936,8 @@ kanawha_models:Kanawha_G2.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Calibration" ;
@@ -3967,7 +4946,8 @@ kanawha_models:Kanawha_G2.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.u06 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996 Calibration" ;
@@ -3976,7 +4956,8 @@ kanawha_models:Kanawha_G2.u06 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003 Calibration" ;
@@ -3985,7 +4966,8 @@ kanawha_models:Kanawha_G2.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016 Calibration" ;
@@ -3994,7 +4976,8 @@ kanawha_models:Kanawha_G2.u08 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "JUN2016_HMS" ;
@@ -4003,7 +4986,8 @@ kanawha_models:New-LittleRiver.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1996_HMS" ;
@@ -4012,7 +4996,8 @@ kanawha_models:New-LittleRiver.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "NOV2003_HMS" ;
@@ -4021,7 +5006,8 @@ kanawha_models:New-LittleRiver.u08 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.u09 a rascat:RasUnsteadyFlow ;
     dcterms:title "restart_file" ;
@@ -4030,7 +5016,8 @@ kanawha_models:New-LittleRiver.u09 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-22T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried false ;
-            rascat:startDateTime "2003-11-18T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-18T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.u10 a rascat:RasUnsteadyFlow ;
     dcterms:title "JAN1995_HMS" ;
@@ -4039,7 +5026,8 @@ kanawha_models:New-LittleRiver.u10 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996" ;
@@ -4048,7 +5036,8 @@ kanawha_models:UpperKanawha.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-04T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-17T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-17T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996_InitialConditions" ;
@@ -4057,7 +5046,8 @@ kanawha_models:UpperKanawha.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-01-17T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.u07 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003_InitialConditions" ;
@@ -4066,7 +5056,8 @@ kanawha_models:UpperKanawha.u07 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-12T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-03T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-03T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.u08 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003" ;
@@ -4075,7 +5066,8 @@ kanawha_models:UpperKanawha.u08 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-12T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.u09 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016_InitialConditions" ;
@@ -4084,7 +5076,8 @@ kanawha_models:UpperKanawha.u09 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-06-22T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-07T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-07T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.u11 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016" ;
@@ -4093,7 +5086,8 @@ kanawha_models:UpperKanawha.u11 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-06-28T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-22T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Restart" ;
@@ -4101,7 +5095,8 @@ kanawha_models:UpperNew_Lower.u01 a rascat:RasUnsteadyFlow ;
             dcterms:description "restart file" ;
             rascat:endDateTime "2000-01-05T12:00:00"^^xsd:dateTime ;
             rascat:spatiallyVaried false ;
-            rascat:startDateTime "2000-01-01T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2000-01-01T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1995" ;
@@ -4110,7 +5105,8 @@ kanawha_models:UpperNew_Lower.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T14:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996" ;
@@ -4119,7 +5115,8 @@ kanawha_models:UpperNew_Lower.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-02T04:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-19T05:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003" ;
@@ -4128,7 +5125,8 @@ kanawha_models:UpperNew_Lower.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T10:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016" ;
@@ -4137,7 +5135,8 @@ kanawha_models:UpperNew_Lower.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T10:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1995" ;
@@ -4146,7 +5145,8 @@ kanawha_models:UpperNew_Upper.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-19T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-11T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov2003" ;
@@ -4155,7 +5155,8 @@ kanawha_models:UpperNew_Upper.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-23T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-16T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan1996" ;
@@ -4164,7 +5165,8 @@ kanawha_models:UpperNew_Upper.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-01-23T00:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-15T00:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun2016" ;
@@ -4173,7 +5175,8 @@ kanawha_models:UpperNew_Upper.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-03T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
@@ -4182,57 +5185,49 @@ kanawha_models:WatershedG3.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.u05 a rascat:RasUnsteadyFlow ;
-    dcterms:title "Jan-1995 IC" .
+    dcterms:title "Jan-1995 IC" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 319443 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG4.g03.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG4.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG4.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG4.g03.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG4.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 273560 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG9.g03.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG9.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG9.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG9.g03.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG9.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 ffrd_people:Daniyal_Siddiqui a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "daniyal.siddiqui@mbakerintl.com" ;
     foaf:member ffrd_orgs:Baker ;
     foaf:name "Daniyal Siddiqui" .
 
 ffrd_people:Jonathan_Bartlotti a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "jonathan.bartlotti@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Jonathan Bartlotti" .
 
 ffrd_people:Julianna_Villa a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "julianna.villa@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Julianna Villa" .
 
 ffrd_people:Reuben_Cozmyer a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "reuben.cozmyer@aecom.com" ;
     foaf:member ffrd_orgs:AECOM ;
     foaf:name "Reuben Cozmyer" .
@@ -4277,9 +5272,9 @@ usgs_gages:03198350 a rascat:Streamgage ;
     dcterms:publisher "USACE" ;
     dcterms:title "Marmet L&D Tailwater" .
 
-<http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/> a rascat:Structures ;
+<http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/#structures> a rascat:Structures ;
     dcterms:description "Structures pulled from existing 1D HEC-RAS models where available." ;
-    dcterms:title "WV State GIS Data Clearinghouse - HEC-RAS Models" .
+    dcterms:title "WV State GIS Data Clearinghouse - HEC-RAS Models (structures)" .
 
 kanawha_models:BasinG6.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
@@ -4288,7 +5283,8 @@ kanawha_models:BasinG6.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995 Initial Conditions" ;
@@ -4297,7 +5293,8 @@ kanawha_models:G5.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Nov2003" ;
@@ -4306,7 +5303,8 @@ kanawha_models:GSummersville_C.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.u05 a rascat:RasUnsteadyFlow ;
     dcterms:title "GauleeSummersville_FloodPlain_Jan1995" ;
@@ -4315,105 +5313,56 @@ kanawha_models:GSummersville_C.u05 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T13:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T13:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.g01 a rascat:RasGeometry ;
     dcterms:title "Greenbrier_G7_LiDAR" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 100 ;
-            rascat:cellCount 250141 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Greenbrier_G7.g01.terrain .
+    rascat:hasMesh2D kanawha_models:Greenbrier_G7.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Greenbrier_G7.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:Greenbrier_G7.g01.roughness ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G7.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.g01 a rascat:RasGeometry ;
     dcterms:title "Greenbrier_G8_LiDAR" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 100 ;
-            rascat:cellCount 291713 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Greenbrier_G8.g01.terrain .
+    rascat:hasMesh2D kanawha_models:Greenbrier_G8.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Greenbrier_G8.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:Greenbrier_G8.g01.roughness ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G8.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 206812 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Kanawha_G1.g02.terrain .
+    rascat:hasMesh2D kanawha_models:Kanawha_G1.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Kanawha_G1.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:Kanawha_G1.g02.roughness ;
+    rascat:hasTerrain kanawha_models:Kanawha_G1.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 206812 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Kanawha_G1.g03.terrain .
+    rascat:hasMesh2D kanawha_models:Kanawha_G1.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Kanawha_G1.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:Kanawha_G1.g03.roughness ;
+    rascat:hasTerrain kanawha_models:Kanawha_G1.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G2.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G2_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 318146 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Kanawha_G2.g02.terrain .
+    rascat:hasMesh2D kanawha_models:Kanawha_G2.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Kanawha_G2.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:Kanawha_G2.g02.roughness ;
+    rascat:hasTerrain kanawha_models:Kanawha_G2.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.g03 a rascat:RasGeometry ;
     dcterms:title "LiDAR_1996" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 411065 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Losses determined from USACE HEC-HMS model for 1996 event" ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG3.g03.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG3.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG3.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG3.g03.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG3.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996" ;
@@ -4422,7 +5371,8 @@ kanawha_models:WatershedG3.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003" ;
@@ -4431,7 +5381,8 @@ kanawha_models:WatershedG3.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016" ;
@@ -4440,24 +5391,16 @@ kanawha_models:WatershedG3.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 319443 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG4.g02.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG4.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG4.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG4.g02.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG4.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
@@ -4466,7 +5409,8 @@ kanawha_models:WatershedG4.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996" ;
@@ -4475,7 +5419,8 @@ kanawha_models:WatershedG4.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003" ;
@@ -4484,7 +5429,8 @@ kanawha_models:WatershedG4.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016" ;
@@ -4493,24 +5439,16 @@ kanawha_models:WatershedG4.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 273560 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG9.g02.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG9.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG9.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG9.g02.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG9.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.u01 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1995" ;
@@ -4519,7 +5457,8 @@ kanawha_models:WatershedG9.u01 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1995-01-29T12:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1995 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1995-01-05T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.u02 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jan-1996" ;
@@ -4528,7 +5467,8 @@ kanawha_models:WatershedG9.u02 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "1996-02-07T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jan1996 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "1996-01-14T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.u03 a rascat:RasUnsteadyFlow ;
     dcterms:title "Nov-2003" ;
@@ -4537,7 +5477,8 @@ kanawha_models:WatershedG9.u03 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2003-11-28T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Nov2003 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2003-11-06T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.u04 a rascat:RasUnsteadyFlow ;
     dcterms:title "Jun-2016" ;
@@ -4546,19 +5487,23 @@ kanawha_models:WatershedG9.u04 a rascat:RasUnsteadyFlow ;
             rascat:endDateTime "2016-07-04T11:00:00"^^xsd:dateTime ;
             rascat:fromHydroEvent kanawha_events:Jun2016 ;
             rascat:spatiallyVaried true ;
-            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] .
+            rascat:startDateTime "2016-06-20T12:00:00"^^xsd:dateTime ] ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 ffrd_orgs:Freese a foaf:Organization ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:homepage <https://www.freese.com/> ;
     foaf:member ffrd_orgs:ARC_JV ;
     foaf:name "Freese and Nichols" .
 
 ffrd_people:Dami_George a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "dami.george@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Dami George" .
 
 ffrd_people:Mark_McBroom a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "mmcbroom@mbakerintl.com" ;
     foaf:member ffrd_orgs:Baker ;
     foaf:name "Mark McBroom" .
@@ -4577,127 +5522,67 @@ kanawha_misc:baker_landuse a rascat:LanduseLandcover ;
     dcterms:creator ffrd_orgs:ARC_JV,
         ffrd_orgs:Baker ;
     dcterms:description "National Agriculture Imagery Program (NAIP) imagery processed using machine learning tools. Pulled August 2022" ;
-    dcterms:title "Baker (ARC) ML-based land use" .
+    dcterms:title "Baker (ARC) ML-based land use" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BasinG6.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G6_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 228618 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:BasinG6.g02.terrain .
+    rascat:hasMesh2D kanawha_models:BasinG6.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:BasinG6.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:BasinG6.g02.roughness ;
+    rascat:hasTerrain kanawha_models:BasinG6.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:ElkMiddle.g01 a rascat:RasGeometry ;
     dcterms:title "ElkMiddle" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 100 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 761035 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 150 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:ElkMiddle.g01.terrain .
+    rascat:hasMesh2D kanawha_models:ElkMiddle.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:ElkMiddle.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:ElkMiddle.g01.roughness ;
+    rascat:hasTerrain kanawha_models:ElkMiddle.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G5_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 230930 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:G5.g02.terrain .
+    rascat:hasMesh2D kanawha_models:G5.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:G5.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:G5.g02.roughness ;
+    rascat:hasTerrain kanawha_models:G5.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G7.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G7_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 100 ;
-            rascat:cellCount 250141 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Greenbrier_G7.g02.terrain .
+    rascat:hasMesh2D kanawha_models:Greenbrier_G7.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Greenbrier_G7.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:Greenbrier_G7.g02.roughness ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G7.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Greenbrier_G8.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G8_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 100 ;
-            rascat:cellCount 291713 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Greenbrier_G8.g02.terrain .
+    rascat:hasMesh2D kanawha_models:Greenbrier_G8.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Greenbrier_G8.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:Greenbrier_G8.g02.roughness ;
+    rascat:hasTerrain kanawha_models:Greenbrier_G8.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 411065 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG3.g01.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG3.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG3.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG3.g01.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG3.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG3.g02 a rascat:RasGeometry ;
     dcterms:title "LiDAR_2016" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 411065 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 1995 and 2016 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG3.g02.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG3.g02.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG3.g02.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG3.g02.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG3.g02.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 ffrd_orgs:Baker a foaf:Organization ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:homepage <https://mbakerintl.com/> ;
     foaf:member ffrd_orgs:ARC_JV ;
     foaf:name "Michael Baker Intl" .
@@ -4779,155 +5664,81 @@ usgs_gages:03200500 a rascat:Streamgage ;
 
 kanawha_models:BasinG6.g01 a rascat:RasGeometry ;
     dcterms:title "GreenbrierBasinG6_LiDAR" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 228618 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:BasinG6.g01.terrain .
+    rascat:hasMesh2D kanawha_models:BasinG6.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:BasinG6.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:BasinG6.g01.roughness ;
+    rascat:hasTerrain kanawha_models:BasinG6.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:BluestoneLocal.g01 a rascat:RasGeometry ;
     dcterms:title "BL-1" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 100 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 417852 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 50 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain kanawha_models:BluestoneLocal.g01.terrain .
+    rascat:hasMesh2D kanawha_models:BluestoneLocal.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:BluestoneLocal.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:BluestoneLocal.g01.roughness ;
+    rascat:hasTerrain kanawha_models:BluestoneLocal.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Bluestone_Upper.g07 a rascat:RasGeometry ;
     dcterms:title "400ft_Refined_100ft_NoSCS" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 400 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 318361 ;
-            rascat:nominalCellSize 400 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain kanawha_models:Bluestone_Upper.g07.terrain .
+    rascat:hasMesh2D kanawha_models:Bluestone_Upper.g07.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Bluestone_Upper.g07.precip_losses ;
+    rascat:hasRoughness kanawha_models:Bluestone_Upper.g07.roughness ;
+    rascat:hasTerrain kanawha_models:Bluestone_Upper.g07.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:CoalRiver.g01 a rascat:RasGeometry ;
     dcterms:description "Nominal rectangular cell spacing of 500' x 500', refined along stream corridors and other breaklines areas to be approximately 100' cells. No losses (e.g. SCS CN) modeled directly in HEC-RAS." ;
     dcterms:title "CoalRiver" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 500 ;
-            rascat:breaklinesMinCellSize 100 ;
-            rascat:cellCount 332739 ;
-            rascat:nominalCellSize 500 ;
-            rascat:refinementRegionsMaxCellSize 50 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain kanawha_models:CoalRiver.g01.terrain .
+    rascat:hasMesh2D kanawha_models:CoalRiver.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:CoalRiver.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:CoalRiver.g01.roughness ;
+    rascat:hasTerrain kanawha_models:CoalRiver.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:G5.g01 a rascat:RasGeometry ;
     dcterms:title "GreenbrierBasinG5_LiDAR" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 230930 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:G5.g01.terrain .
+    rascat:hasMesh2D kanawha_models:G5.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:G5.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:G5.g01.roughness ;
+    rascat:hasTerrain kanawha_models:G5.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_B.g01 a rascat:RasGeometry ;
     dcterms:title "GauleySummersville_Existing" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 587360 ;
-            rascat:nominalCellSize 500 ;
-            rascat:refinementRegionsMaxCellSize 200 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/> ;
-    rascat:hasTerrain kanawha_models:GSummersville_B.g01.terrain .
+    rascat:hasMesh2D kanawha_models:GSummersville_B.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:GSummersville_B.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:GSummersville_B.g01.roughness ;
+    rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/#structures> ;
+    rascat:hasTerrain kanawha_models:GSummersville_B.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GauleyLower_BLE_FEM.g01 a rascat:RasGeometry ;
     dcterms:title "Gauley_Lower" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 1088388 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 50 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover kanawha_misc:baker_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:baker_landuse ] ;
-    rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/> ;
-    rascat:hasTerrain kanawha_models:GauleyLower_BLE_FEM.g01.terrain .
+    rascat:hasMesh2D kanawha_models:GauleyLower_BLE_FEM.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:GauleyLower_BLE_FEM.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:GauleyLower_BLE_FEM.g01.roughness ;
+    rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/#structures> ;
+    rascat:hasTerrain kanawha_models:GauleyLower_BLE_FEM.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:Kanawha_G1.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G1" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 206812 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Kanawha_G1.g01.terrain .
+    rascat:hasMesh2D kanawha_models:Kanawha_G1.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Kanawha_G1.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:Kanawha_G1.g01.roughness ;
+    rascat:hasTerrain kanawha_models:Kanawha_G1.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Upper.g01 a rascat:RasGeometry ;
     dcterms:title "UpperNew_Upper_geom" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 100 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 1064723 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 50 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain kanawha_models:UpperNew_Upper.g01.terrain .
+    rascat:hasMesh2D kanawha_models:UpperNew_Upper.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:UpperNew_Upper.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:UpperNew_Upper.g01.roughness ;
+    rascat:hasTerrain kanawha_models:UpperNew_Upper.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 ffrd_orgs:ARC_JV a foaf:Organization ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:name "ARC JV" .
 
 usgs_gages:03196800 a rascat:Streamgage ;
@@ -4937,122 +5748,62 @@ usgs_gages:03196800 a rascat:Streamgage ;
 
 kanawha_models:Kanawha_G2.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR_G2" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 318146 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:Kanawha_G2.g01.terrain .
+    rascat:hasMesh2D kanawha_models:Kanawha_G2.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:Kanawha_G2.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:Kanawha_G2.g01.roughness ;
+    rascat:hasTerrain kanawha_models:Kanawha_G2.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:New-LittleRiver.g01 a rascat:RasGeometry ;
     dcterms:title "New_Little_River" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 100 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 517580 ;
-            rascat:nominalCellSize 200 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasTerrain kanawha_models:New-LittleRiver.g01.terrain .
+    rascat:hasMesh2D kanawha_models:New-LittleRiver.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:New-LittleRiver.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:New-LittleRiver.g01.roughness ;
+    rascat:hasTerrain kanawha_models:New-LittleRiver.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperNew_Lower.g03 a rascat:RasGeometry ;
     dcterms:title "Simplified" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 800701 ;
-            rascat:nominalCellSize 1000 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasStructures [ a rascat:Structures ;
-            dcterms:description "Description of hydraulic data and water surface elevations of the dam was used to create a rating curve" ;
-            dcterms:relation <http://claytorhydro.com/lib/docs/ClaytorWaterManagementPlanJune2009asapprovedbyFERCDec2011.pdf>,
-                <https://hydroreform.org/wp-content/uploads/2020/09/New-River-Virginia-Final.pdf> ] ;
-    rascat:hasTerrain kanawha_models:UpperNew_Lower.g03.terrain .
+    rascat:hasMesh2D kanawha_models:UpperNew_Lower.g03.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:UpperNew_Lower.g03.precip_losses ;
+    rascat:hasRoughness kanawha_models:UpperNew_Lower.g03.roughness ;
+    rascat:hasStructures kanawha_models:UpperNew_Lower.g03.structures ;
+    rascat:hasTerrain kanawha_models:UpperNew_Lower.g03.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG4.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 319443 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG4.g01.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG4.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG4.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG4.g01.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG4.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:WatershedG9.g01 a rascat:RasGeometry ;
     dcterms:title "LiDAR" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 50 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 273560 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 100 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            dcterms:description "Calibrated CN Losses for 2003 storm event" ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:wsp_landuse ] ;
-    rascat:hasTerrain kanawha_models:WatershedG9.g01.terrain .
+    rascat:hasMesh2D kanawha_models:WatershedG9.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:WatershedG9.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:WatershedG9.g01.roughness ;
+    rascat:hasTerrain kanawha_models:WatershedG9.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:GSummersville_C.g01 a rascat:RasGeometry ;
     dcterms:title "GauleySummersville_Existing" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 954995 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 200 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover kanawha_misc:baker_landuse ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover kanawha_misc:baker_landuse ] ;
-    rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/> ;
-    rascat:hasTerrain kanawha_models:GSummersville_C.g01.terrain .
+    rascat:hasMesh2D kanawha_models:GSummersville_C.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:GSummersville_C.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:GSummersville_C.g01.roughness ;
+    rascat:hasStructures <http://data.wvgis.wvu.edu/pub/Clearinghouse/hazards/WV_HEC_RAS_Model/#structures> ;
+    rascat:hasTerrain kanawha_models:GSummersville_C.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_models:UpperKanawha.g01 a rascat:RasGeometry ;
     dcterms:title "UpperKanawha" ;
-    rascat:hasMesh2D [ a rascat:Mesh2D ;
-            rascat:breaklinesMaxCellSize 200 ;
-            rascat:breaklinesMinCellSize 50 ;
-            rascat:cellCount 537254 ;
-            rascat:nominalCellSize 200 ;
-            rascat:refinementRegionsMaxCellSize 50 ;
-            rascat:refinementRegionsMinCellSize 50 ] ;
-    rascat:hasPrecipLosses [ a rascat:PrecipLosses ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ;
-            rascat:hasSoils <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> ] ;
-    rascat:hasRoughness [ a rascat:Roughness ;
-            rascat:hasLanduseLandcover <https://www.mrlc.gov/data/nlcd-2019-land-cover-conus> ] ;
-    rascat:hasStructures [ a rascat:Structures ;
-            dcterms:description "London/Marmet L&D Structures and Gate operations copied from USACE CWMS Model" ;
-            dcterms:title "USACE Kanawaha CWMS Model" ] ;
-    rascat:hasTerrain kanawha_models:UpperKanawha.g01.terrain .
+    rascat:hasMesh2D kanawha_models:UpperKanawha.g01.mesh2d ;
+    rascat:hasPrecipLosses kanawha_models:UpperKanawha.g01.precip_losses ;
+    rascat:hasRoughness kanawha_models:UpperKanawha.g01.roughness ;
+    rascat:hasStructures kanawha_models:UpperKanawha.g01.structures ;
+    rascat:hasTerrain kanawha_models:UpperKanawha.g01.terrain ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 usgs_gages:03197000 a rascat:Streamgage ;
     dcterms:identifier "03197000" ;
@@ -5075,21 +5826,25 @@ usgs_gages:03192000 a rascat:Streamgage ;
     dcterms:title "Summersville Lake" .
 
 ffrd_orgs:AECOM a foaf:Organization ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:homepage <https://www.aecom.com/> ;
-    foaf:member ffrd_orgs:Compass_JV ;
+    foaf:member ffrd_orgs:Compass_PTS_JV ;
     foaf:name "AECOM" .
 
 ffrd_people:Ben_Rufenacht a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "ben.rufenacht@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Ben Rufenacht" .
 
 ffrd_people:Josh_Hill a foaf:Person ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:mbox "josh.hill@wsp.com" ;
     foaf:member ffrd_orgs:WSP ;
     foaf:name "Josh Hill" .
 
 ffrd_orgs:WSP a foaf:Organization ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." ;
     foaf:homepage <https://www.wsp.com/> ;
     foaf:member ffrd_orgs:ARC_JV ;
     foaf:name "WSP, Inc." .
@@ -5110,39 +5865,52 @@ usgs_gages:03189100 a rascat:Streamgage ;
 
 kanawha_models:mmc_albers_ft.prj a rascat:Projection ;
     dcterms:description "Modified version of ESRI:102309, provided by USACE. Units are in feet, whereas EPSG:102309 is in meters." ;
-    dcterms:title "Albers Equal Area Conic (feet)" .
+    dcterms:title "Albers Equal Area Conic (feet)" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
+
+kanawha_misc:greenbrier_riskmap_bathymetry a rascat:Bathymetry ;
+    dcterms:description "Channel data pulled from ongoing 1D HEC-RAS models for the Greenbrier River from ongiong WSP FEMA Risk MAP studies in the area" ;
+    dcterms:title "Greenbrier River bathymetry from active Risk MAP projects" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 <https://www.nrcs.usda.gov/resources/data-and-reports/soil-survey-geographic-database-ssurgo> a rascat:Soils ;
     dcterms:description "USDA / NRCS Soil Survey Geographic Database (SSURGO)" ;
     dcterms:title "SSURGO" .
 
 <https://femahq.s3.amazonaws.com/kanawha/tiles/1m> a rascat:DEM ;
+    dcterms:creator ffrd_people:Seth_Lawler ;
     dcterms:description "Digital Elevation Model for the Kanawha River Basin, based on USGS 3DEP data." ;
-    dcterms:title "Kanawha River Basin DEM" .
+    dcterms:title "Kanawha River Basin DEM" ;
+    rdfs:comment "Data access via AWS S3. Contact STARR II / Dewberry for more information." .
 
 kanawha_misc:wsp_landuse a rascat:LanduseLandcover ;
     dcterms:creator ffrd_orgs:ARC_JV,
         ffrd_orgs:WSP ;
     dcterms:description "Custom machine learning land cover analysis of NAIP 2022 imagery" ;
-    dcterms:title "WSP (ARC) ML-based land use" .
+    dcterms:title "WSP (ARC) ML-based land use" ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_events:Jan1996 a rascat:HydroEvent ;
     dcterms:title "January 1996" ;
     rascat:endDateTime "1995-02-01T00:00:00"^^xsd:dateTime ;
-    rascat:startDateTime "1995-01-15T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-15T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_events:Jan1995 a rascat:HydroEvent ;
     dcterms:title "January 1995" ;
     rascat:endDateTime "1995-01-25T00:00:00"^^xsd:dateTime ;
-    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "1995-01-06T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_events:Nov2003 a rascat:HydroEvent ;
     dcterms:title "November 2003" ;
     rascat:endDateTime "2003-11-24T00:00:00"^^xsd:dateTime ;
-    rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2003-11-06T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 
 kanawha_events:Jun2016 a rascat:HydroEvent ;
     dcterms:title "June 2016" ;
     rascat:endDateTime "2016-07-01T00:00:00"^^xsd:dateTime ;
-    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime .
+    rascat:startDateTime "2016-06-20T00:00:00"^^xsd:dateTime ;
+    rdfs:comment "URL not currently available. A placeholder is used for demonstration purposes." .
 

--- a/rascat.ttl
+++ b/rascat.ttl
@@ -94,9 +94,6 @@
 #################################################################
 # Geometry
 #################################################################
-# Questions
-# - how many Terrains can a single Geometry have?
-# - how many Roughnesses can a single Geometry have?
 
 ###  http://www.example.org/rascat#RasGeometry
 :RasGeometry a owl:Class ;
@@ -104,83 +101,97 @@
         rdfs:subClassOf dcat:Dataset .
 
 :hasTerrain a owl:ObjectProperty ;
+        rdfs:comment "A HEC-RAS Terrain associated with a parent RasGeometry."@en ;
         rdfs:domain :RasGeometry ;
         rdfs:range :Terrain .
       
 :hasRoughness a owl:ObjectProperty ;
+        rdfs:comment "Roughness (e.g., Manning's 'n') data associated with a parent RasGeometry."@en ;
         rdfs:domain :RasGeometry ;
         rdfs:range :Roughness .
 
 :hasPrecipLosses a owl:ObjectProperty ;
+        rdfs:comment "Precipitation loss base data associated with a parent RasGeometry."@en ;
         rdfs:domain :RasGeometry ;
         rdfs:range :PrecipLosses .
 
 :hasMesh2D a owl:ObjectProperty ;
+        rdfs:comment "A HEC-RAS 2D mesh associated with a parent RasGeometry."@en ;
         rdfs:domain :RasGeometry ;
         rdfs:range :Mesh2D .
 
 :hasStructures a owl:ObjectProperty ;
+        rdfs:comment "Structure data associated with a RasGeometry."@en ;
         rdfs:domain :RasGeometry ;
         rdfs:range :Structures .
 
 ### http://www.example.org/rascat#Terrain
 :Terrain a owl:Class ;
+        rdfs:comment "A HEC-RAS Terrain."@en ;
         rdfs:subClassOf dcat:Dataset ;
         owl:equivalentClass [ a owl:Restriction ;
                 owl:onProperty :hasDEM ;
                 owl:minCardinality 1 ] .
 
 :hasDEM a owl:ObjectProperty ;
+        rdfs:comment "A Digital Elevation Model (DEM) associated with a parent HEC-RAS Terrain."
         rdfs:domain :Terrain ;
         rdfs:range :DEM .
 
 :hasBathymetry a owl:ObjectProperty ;
+        rdfs:comment "Bathymetry data associated with a parent HEC-RAS Terrain."
         rdfs:domain :Terrain ;
         rdfs:range :Bathymetry .
 
 :hasTerrainModifications a owl:ObjectProperty ;
+        rdfs:comment "Information about modifications to the terrain associated with a parent HEC-RAS Terrain."
         rdfs:domain :Terrain ;
         rdfs:range :TerrainModifications .
 
 ### http://www.example.org/rascat#DEM
 :DEM a owl:Class ;
+        rdfs:comment "A Digital Elevation Model (DEM)."@en ;
         rdfs:subClassOf dcat:Dataset .
 
 ### http://www.example.org/rascat#Bathymetry
 :Bathymetry a owl:Class ;
+        rdfs:comment "Bathymetry data."@en ;
         rdfs:subClassOf dcat:Dataset .
 
 ### http://www.example.org/rascat#TerrainModifications
 :TerrainModifications a owl:Class ;
+        rdfs:comment "Information about modifications to the terrain."@en ;
         rdfs:subClassOf dcat:Dataset .
 
 ### http://www.example.org/rascat#Roughness
 :Roughness a owl:Class ;
+        rdfs:comment "Roughness (e.g., Manning's 'n') data."@en ;
         rdfs:subClassOf dcat:Dataset .
-
-:hasRoughness a owl:ObjectProperty ;
-        rdfs:domain :RasGeometry ;
-        rdfs:range :Roughness .
 
 ### http://www.example.org/rascat#LanduseLandcover
 :LanduseLandcover a owl:Class ;
+        rdfs:comment "Land use / land cover data."@en ;
         rdfs:subClassOf dcat:Dataset .
 
 :hasLanduseLandcover a owl:ObjectProperty ;
+        rdfs:comment "Land use / land cover data associated with a parent HEC-RAS Roughness or PrecipLosses."@en ;
         rdfs:domain :Roughness ;
         rdfs:domain :PrecipLosses ;
         rdfs:range :LanduseLandcover .
 
 ### http://www.example.org/rascat#PrecipLosses
 :PrecipLosses a owl:Class ;
+        rdfs:comment "Precipitation loss base data."@en ;
         rdfs:subClassOf dcat:Dataset .
 
 :hasSoils a owl:ObjectProperty ;
+        rdfs:comment "Soils data associated with HEC-RAS PrecipLosses."@en ;
         rdfs:domain :PrecipLosses ;
         rdfs:range :Soils .
 
 ### http://www.example.org/rascat#Soils
 :Soils a owl:Class ;
+        rdfs:comment "Soils data."@en ;
         rdfs:subClassOf dcat:Dataset .
 
 ### http://www.example.org/rascat#Mesh2D
@@ -247,12 +258,13 @@
 
 ### http://www.example.org/rascat#RasUnsteadyFlow
 :RasUnsteadyFlow a owl:Class ;
-        rdfs:comment "A HEC-RAS Unsteady Flow file. (e.g., *.u01)"@en;
+        rdfs:comment "A HEC-RAS Unsteady Flow file. (e.g., *.u01)"@en ;
         rdfs:subClassOf :RasFlow ;
         rdfs:subClassOf dcat:Dataset .
 
 ### http://www.example.org/rascat#Hydrodata
 :Hydrodata a owl:Class ;
+        rdfs:comment "Class representing generic hydrologic data."@en ;
         rdfs:subClassOf dcat:Dataset ;
         owl:equivalentClass [ a owl:Restriction ;
                 owl:onProperty :startDateTime ;
@@ -267,67 +279,63 @@
                 owl:onProperty :fromHydroEvent ;
                 owl:maxCardinality 1 ] .
 
+:startDateTime a owl:ObjectProperty ;
+        rdfs:comment "The start date and time of the hydrologic data."@en ;
+        rdfs:subClassOf dcat:startDate;
+        rdfs:domain :HydroData ;
+        rdfs:range xsd:dateTime .
+
+:endDateTime a owl:ObjectProperty ;
+        rdfs:comment "The end date and time of the hydrologic data."@en
+        rdfs:subClassOf dcat:endDate;
+        rdfs:domain :HydroData ;
+        rdfs:range xsd:dateTime .
+
 ### http://www.example.org/rascat#Hydrograph
 :Hydrograph a owl:Class ;
+        rdfs:comment "Class representing a hydrograph."@en ;
         rdfs:subClassOf :Hydrodata ;
         rdfs:subClassOf dcat:Dataset .
 
 :hydrographType a owl:ObjectProperty ;
+        rdfs:comment "The type of hydrograph - Flow or Stage."@en ;
         rdfs:domain :RasModel ;
         rdfs:range [ owl:oneOf ("Flow" "Stage") ] .
 
-:startDateTime a owl:ObjectProperty ;
-        rdfs:subClassOf dcat:startDate;
-        rdfs:domain :HydroEvent ;
-        rdfs:domain :Hyetograph ;
-        rdfs:domain :Hydrograph ;
-        rdfs:range xsd:dateTime .
-
-:endDateTime a owl:ObjectProperty ;
-        rdfs:subClassOf dcat:endDate;
-        rdfs:domain :HydroEvent ;
-        rdfs:domain :Hyetograph ;
-        rdfs:domain :Hydrograph ;
-        rdfs:range xsd:dateTime .
-
 :hasInflowHydrograph a owl:ObjectProperty ;
+        rdfs:comment "The hydrograph used as inflow for a HEC-RAS model."@en ;
         rdfs:domain :RasFlow ;
         rdfs:range :Hydrograph .
 
 :hasCalibrationHydrograph a owl:ObjectProperty ;
+        rdfs:comment "The hydrograph used as calibration data for a HEC-RAS model."@en ;
         rdfs:domain :RasPlan ;
         rdfs:range :Hydrograph .
 
-:hasValidationHydrograph a owl:ObjectProperty ;
-        rdfs:domain :RasUnsteadyFlow ;
-        rdfs:range :Hydrograph .
-
-:hasObservedHydrograph a owl:ObjectProperty ;
-        rdfs:domain :RasUnsteadyFlow ;
-        rdfs:range :Hydrograph .
-
 :calibrationMetric a owl:ObjectProperty ;
+        rdfs:comment "A metric used to evaluate the calibration of a HEC-RAS model."@en ;
         rdfs:domain :Hydrograph ;
         rdfs:range xsd:double .
 
 :nse a owl:ObjectProperty ;
         rdfs:subClassOf :calibrationMetric ;
-        rdfs:comment "Nash-Sutcliffe Efficiency" .
+        rdfs:comment "Nash-Sutcliffe Efficiency"@en .
 
 :pbias a owl:ObjectProperty ;
         rdfs:subClassOf :calibrationMetric ;
-        rdfs:comment "Percent Bias" .
+        rdfs:comment "Percent Bias"@en .
 
 :rsr a owl:ObjectProperty ;
         rdfs:subClassOf :calibrationMetric ;
-        rdfs:comment "Root Mean Square Error Standard Deviation Ratio" .
+        rdfs:comment "Root Mean Square Error Standard Deviation Ratio"@en .
 
 :r2 a owl:ObjectProperty ;
         rdfs:subClassOf :calibrationMetric ;
-        rdfs:comment "Coefficient of Determination" .
+        rdfs:comment "Coefficient of Determination"@en .
 
 ### http://www.example.org/rascat#Hyetograph
 :Hyetograph a owl:Class ;
+        rdfs:comment "Class representing a hyetograph."@en ;
         rdfs:subClassOf :Hydrodata;
         rdfs:subClassOf dcat:Dataset ;
         owl:equivalentClass [ a owl:Restriction ;
@@ -335,27 +343,33 @@
                 owl:cardinality 1 ] .
 
 :fromHydroEvent a owl:ObjectProperty ;
+        rdfs:comment "The real-world hydrologic event used to generate the hyetograph."@en ;
         rdfs:domain :Hyetograph ;
         rdfs:range :HydroEvent .
 
 :isSpatiallyVaried a owl:ObjectProperty ;
+        rdfs:comment "Indicates whether the hyetograph is spatially varied. Non-spatially varied hyetographs apply over the full domain of a 2D mesh."@en ;
         rdfs:domain :Hyetograph ;
         rdfs:range xsd:boolean .
 
 :hasHyetograph a owl:ObjectProperty ;
+        rdfs:comment "The hyetograph used as inflow for a HEC-RAS model."@en ;
         rdfs:domain :RasUnsteadyFlow ;
         rdfs:range :Hyetograph .
 
 ### http://www.example.org/rascat#Streamgage
 :Streamgage a owl:Class ;
+        rdfs:comment "Class representing a streamgage."@en ;
         rdfs:subClassOf dcat:Dataset .
 
 :fromStreamgage a owl:ObjectProperty ;
+        rdfs:comment "The streamgage from which a hydrograph was obtained."@en ;
         rdfs:domain :Hydrograph ;
         rdfs:range :Streamgage .
 
 ### http://www.example.org/rascat#HydroEvent
 :HydroEvent a owl:Class ;
+        rdfs:comment "Class representing a real-world hydrologic event (e.g., a storm event)."@en ;
         rdfs:subClassOf dcat:Dataset .
 
 ###  Generated by the OWL API (version 4.5.24.2023-01-14T21:28:32Z) https://github.com/owlcs/owlapi

--- a/rascat.ttl
+++ b/rascat.ttl
@@ -307,14 +307,26 @@
         rdfs:domain :RasFlow ;
         rdfs:range :Hydrograph .
 
-:hasCalibrationHydrograph a owl:ObjectProperty ;
-        rdfs:comment "The hydrograph used as calibration data for a HEC-RAS model."@en ;
+
+### http://www.example.org/rascat#Calibration
+:Calibration a owl:Class ;
+        rdfs:comment "Class representing the calibration of a HEC-RAS model (i.e., Plan)."@en ;
+        rdfs:subClassOf :Hydrodata ;
+        rdfs:subClassOf dcat:Dataset .
+
+:hasCalibration a owl:ObjectProperty ;
+        rdfs:comment "Calibration associated with a HEC-RAS Plan."@en ;
         rdfs:domain :RasPlan ;
+        rdfs:range :Hydrograph .
+
+:hasObservedHydrograph a owl:ObjectProperty ;
+        rdfs:comment "The observed hydrograph used to calibrate a HEC-RAS model."@en ;
+        rdfs:domain :Calibration ;
         rdfs:range :Hydrograph .
 
 :calibrationMetric a owl:ObjectProperty ;
         rdfs:comment "A metric used to evaluate the calibration of a HEC-RAS model."@en ;
-        rdfs:domain :Hydrograph ;
+        rdfs:domain :Calibration ;
         rdfs:range xsd:double .
 
 :nse a owl:ObjectProperty ;
@@ -332,6 +344,7 @@
 :r2 a owl:ObjectProperty ;
         rdfs:subClassOf :calibrationMetric ;
         rdfs:comment "Coefficient of Determination"@en .
+
 
 ### http://www.example.org/rascat#Hyetograph
 :Hyetograph a owl:Class ;

--- a/streamgages.yml
+++ b/streamgages.yml
@@ -24,6 +24,26 @@
   owner: USACE
   link: https://www.lrh-wc.usace.army.mil/wm/?basin/kan/sug
 
+- identifier: USACE_London_LD_Pool
+  title: London L&D Pool
+  owner: USACE
+  link: https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#London%20L&D%20Pool
+
+- identifier: USACE_London_LD_Tailwater
+  title: London L&D Tailwater
+  owner: USACE
+  link: https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#London%20L&D%20Tailwater
+
+- identifier: USACE_Marmet_LD_Pool
+  title: Marmet L&D Pool
+  owner: USACE
+  link: https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#Marmet%20L&D%20Pool
+
+- identifier: USACE_Marmet_LD_Tailwater
+  title: Marmet L&D Tailwater
+  owner: USACE
+  link: https://www.lrh-wc.usace.army.mil/wm/?river/kanawha#Marmet%20L&D%20Tailwater
+
 - identifier: 03189100
   title: Gauley River Near Craigsville, WV
 
@@ -45,7 +65,7 @@
 - identifier: 03182888
   title: Dry Creek at Tuckahoe, WV
 
-- identifier: 03183500
+- identifier: 03184000
   title: Greenbrier River at Hilldale, WV
 
 - identifier: "03177710"
@@ -86,3 +106,9 @@
 
 - identifier: "03164000"
   title: New River Near Galax, VA
+
+- identifier: "03188900"
+  title: Laurel Creek Near Fenwick, WV
+
+- identifier: 03183500
+  title: Greenbrier River at Alderson, WV


### PR DESCRIPTION
* Comments `rascat` on classes and properties to indicate their purpose.
* `rascat:Calibration` class.
* Bit of script cleanup in `create_kanawha_metadata.py`
* Separate out most blank nodes in `kanawha.ttl`
  * Note that this results in a lot of technically unresolvable URLs (e.g., `UpperKanawha.g01.terrain`). But seeing as how this is a demonstration project and our base prefix `https://example.ffrd.fema.gov/` isn't real anyway, it seems like that's probably okay.